### PR TITLE
fix: correct Windows layout compression caused by native title bar

### DIFF
--- a/main.js
+++ b/main.js
@@ -45,9 +45,14 @@ function testnetToMainnet() {
 }
 
 function createWindow() {
+    // On Windows, the native title bar (~30px) reduces the available content area,
+    // so we add extra height to compensate and avoid layout compression.
+    const titleBarHeight = process.platform === 'win32' ? 30 : 0;
+    const windowHeight = 590 + titleBarHeight;
+
     const mainWindow = new BrowserWindow({
         width: 905,
-        height: 590,
+        height: windowHeight,
         webPreferences: {
             nodeIntegration: false,
             contextIsolation: true,
@@ -56,7 +61,7 @@ function createWindow() {
         },
     });
 
-    mainWindow.setMinimumSize(905, 590);
+    mainWindow.setMinimumSize(905, windowHeight);
     // mainWindow.setMaximumSize(905, 650);
     mainWindow.loadFile(path.join(__dirname, 'dist', 'index.html'));
 

--- a/src/ui/layouts/Layout.module.scss
+++ b/src/ui/layouts/Layout.module.scss
@@ -1,5 +1,5 @@
 .layout {
-  height: 100vh;
+  min-height: 100vh;
   max-width: 90rem;
   margin: 0 auto;
   display: flex;

--- a/src/ui/pages/DAO/Deposit/Deposit.module.scss
+++ b/src/ui/pages/DAO/Deposit/Deposit.module.scss
@@ -1,6 +1,6 @@
 .depositForm {
   :global {
-    height: 45rem;
+    min-height: 45rem;
     background: rgba(255, 255, 255, 0.02);
     backdrop-filter: blur(12px);
     padding-top: 3.5rem;

--- a/src/ui/pages/DAO/RequestWithdraw/RequestWithdraw.module.scss
+++ b/src/ui/pages/DAO/RequestWithdraw/RequestWithdraw.module.scss
@@ -1,6 +1,6 @@
 .withdrawRequestForm {
   :global {
-    height: 45rem;
+    min-height: 45rem;
     background: rgba(255, 255, 255, 0.02);
     backdrop-filter: blur(12px);
 

--- a/src/ui/pages/DAO/Withdraw/Withdraw.module.scss
+++ b/src/ui/pages/DAO/Withdraw/Withdraw.module.scss
@@ -1,6 +1,6 @@
 .withdrawForm {
   :global {
-    height: 45rem;
+    min-height: 45rem;
     background: rgba(255, 255, 255, 0.02);
     backdrop-filter: blur(12px);
 

--- a/src/ui/pages/Receive/Receive.module.scss
+++ b/src/ui/pages/Receive/Receive.module.scss
@@ -1,5 +1,5 @@
 .receiveContainer {
-  height: 45rem;
+  min-height: 45rem;
   display: flex;
   flex-direction: column;
   background: rgba(255, 255, 255, 0.02);

--- a/src/ui/pages/Send/Send.module.scss
+++ b/src/ui/pages/Send/Send.module.scss
@@ -1,6 +1,6 @@
 .sendForm {
   :global {
-    height: 45rem;
+    min-height: 45rem;
     background: rgba(255, 255, 255, 0.02);
     backdrop-filter: blur(12px);
     padding-top: 3.5rem;

--- a/src/ui/pages/Settings/Accounts/Accounts.module.scss
+++ b/src/ui/pages/Settings/Accounts/Accounts.module.scss
@@ -1,5 +1,5 @@
 .wallet {
-  height: 45rem;
+  min-height: 45rem;
   :global {
     display: flex;
     flex-direction: column;

--- a/src/ui/pages/Settings/EjectWallet/EjectWallet.module.scss
+++ b/src/ui/pages/Settings/EjectWallet/EjectWallet.module.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   background: rgba(255, 255, 255, 0.02);
   backdrop-filter: blur(12px);
-  height: 45rem;
+  min-height: 45rem;
 
   .content {
     display: flex;

--- a/src/ui/pages/Settings/RevealSRP/RevealSRP.module.scss
+++ b/src/ui/pages/Settings/RevealSRP/RevealSRP.module.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   background: rgba(255, 255, 255, 0.02);
   backdrop-filter: blur(12px);
-  height: 45rem;
+  min-height: 45rem;
   .content {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
On Windows, the native title bar reduces the available content area below the configured window size. Compensate by adding 30px to window height on Windows, and replace fixed heights with min-height on layout and all page containers to prevent overflow and top-edge clipping of status cards.

Fixes #121