### PR TITLE
feat: add ML-DSA-65 (FIPS 204) as an alternative signature scheme

### DIFF
--- a/docs/mldsa65-testing.md
+++ b/docs/mldsa65-testing.md
@@ -1,0 +1,160 @@
+# ML-DSA-65 Testing Guide
+
+This document covers how to build and test the ML-DSA-65 (FIPS 204) feature branch
+(`feat/mldsa65`) before it is published to npm. The WASM binary is already compiled
+into the bundle, so no Rust toolchain is required for basic testing.
+
+---
+
+## Quick Test — Deploy Pre-Built Bundle to Vercel
+
+The `public/` folder contains a production webpack build with the ML-DSA-65 WASM
+already compiled in. You can deploy it as a static site in under a minute:
+
+```bash
+# Install Vercel CLI if needed
+npm i -g vercel
+
+# Clone this branch
+git clone -b feat/mldsa65 https://github.com/toastmanAu/quantum-purse.git
+cd quantum-purse
+
+# Deploy the pre-built output — no rebuild required
+vercel deploy public/ --name quantum-purse-mldsa-test
+```
+
+Vercel will give you a preview URL (e.g. `https://quantum-purse-mldsa-test-xxx.vercel.app`).
+Open it in **Chrome, Brave, or Safari** — the light client requires SharedArrayBuffer,
+which needs the COOP/COEP headers already set in `vercel.json`.
+
+---
+
+## What to Test
+
+### 1. Wallet Setup
+
+- [ ] Create a new wallet with a password
+- [ ] Record the seed phrase shown during setup
+- [ ] Confirm the wallet loads to the main screen
+
+### 2. Create an ML-DSA-65 Account
+
+- [ ] Navigate to **Accounts → New Account**
+- [ ] Select **ML-DSA-65** as the signature scheme
+- [ ] Confirm an address beginning with `ckt` (testnet) is generated
+- [ ] Confirm the address is distinct from any SPHINCS+ address on the same wallet
+
+### 3. SPHINCS+ Coexistence
+
+- [ ] Create a second account using **SPHINCS+**
+- [ ] Confirm both accounts appear in the account list
+- [ ] Confirm each shows its correct scheme label
+- [ ] Switch between accounts and verify addresses update correctly
+
+### 4. Receive Funds (Testnet)
+
+- [ ] Copy the ML-DSA-65 account address
+- [ ] Request testnet CKB from the [Nervos faucet](https://faucet.nervos.org/)
+  - Minimum 73 CKB required (quantum-resistant lock scripts need more capacity)
+- [ ] Wait for the light client to sync (peer count and sync % shown in header)
+- [ ] Confirm the balance appears on the ML-DSA-65 account
+
+### 5. Send a Transaction
+
+- [ ] Navigate to **Send** with the ML-DSA-65 account selected
+- [ ] Enter a testnet destination address and an amount (≥ 73 CKB recommended)
+- [ ] Enter your wallet password when prompted
+- [ ] Confirm the transaction is broadcast and appears in the CKB testnet explorer
+  - Explorer: https://testnet.explorer.nervos.org/
+
+### 6. Wallet Recovery
+
+- [ ] Delete the wallet (clear IndexedDB via browser DevTools → Application → Storage)
+- [ ] Restore from the seed phrase recorded in step 1
+- [ ] Confirm ML-DSA-65 accounts are recovered via **Recover Accounts**
+  > **Note:** Light client sync speed affects batch recovery. If only the first
+  > account appears, create additional accounts manually and use the context menu
+  > to set the correct starting block from the explorer.
+
+### 7. Cross-Scheme Send
+
+- [ ] Send from a **SPHINCS+** account to the **ML-DSA-65** address
+- [ ] Confirm receipt on the ML-DSA-65 account
+- [ ] Send from **ML-DSA-65** back to the **SPHINCS+** address
+- [ ] Confirm both transactions appear correctly in explorer
+
+---
+
+## Build From Source (Optional)
+
+If you want to verify the full build rather than using the pre-built bundle:
+
+### Prerequisites
+
+```bash
+# Rust + wasm toolchain
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup target add wasm32-unknown-unknown
+curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+# Node
+node >= 18, npm >= 9
+```
+
+### Build
+
+```bash
+# 1. Build the WASM key vault
+git clone -b feat/mldsa65 https://github.com/toastmanAu/key-vault-wasm.git
+cd key-vault-wasm
+bash build.sh
+cd ..
+
+# 2. Build the web app pointing at the local WASM
+git clone -b feat/mldsa65 https://github.com/toastmanAu/quantum-purse.git
+cd quantum-purse
+npm install ../key-vault-wasm/dist
+npm run build:web
+
+# 3. Deploy or serve locally
+vercel deploy public/ --name quantum-purse-mldsa-test
+# or: npx serve public/
+```
+
+---
+
+## Known Limitations (This Branch)
+
+| Limitation | Details |
+|------------|---------|
+| Mainnet lock script | ML-DSA-65 lock is testnet-only (`ckb-mldsa-lock`). Mainnet deployment pending review. |
+| `key-vault-wasm` not on npm | Using local path dep. Will be published after review. |
+| Deterministic signing | Uses `try_sign_with_seed([0u8;32])` — the hedging seed is fixed zeros. Acceptable for CKB (deterministic signing is standard practice); can be upgraded to OS randomness post-review. |
+| Batch account recovery | Same light-client sync limitation as SPHINCS+ — only first account auto-recovers on slow sync. |
+
+---
+
+## Key Changes in This Branch
+
+### `key-vault-wasm` (`feat/mldsa65`)
+
+- New crate: `crates/ckb-fips204-utils` — ML-DSA-65 key derivation and signing
+- `src/lib.rs` — `gen_new_ml_dsa_account`, `sign_ml_dsa`, `recover_ml_dsa_accounts`, `get_all_ml_dsa_lock_args`
+- `src/db.rs` — `MlDsaAccount` record type, IndexedDB store `ml-dsa-accounts`
+- Same master seed covers both SPHINCS+ and ML-DSA-65 via separate HKDF paths — **no new backup needed**
+
+### `quantum-purse` (`feat/mldsa65`)
+
+- `src/core/config.ts` — `MLDSA_LOCK` config, `SigScheme` type
+- `src/core/quantum_purse.ts` — `genNewMlDsaAccount`, `recoverMlDsaAccounts`, scheme-aware `getAddress`
+- `src/core/ccc-adapter/qp_signer.ts` — `QpMlDsaSigner` extending `CCC Signer`
+- `src/ui/` — account type selector, ML-DSA badge, scheme-aware send flow
+
+---
+
+## Reporting Issues
+
+Please comment on the PR with:
+- Browser and OS
+- Which test step failed
+- Any console errors (F12 → Console)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@rematch/loading": "2.1.2",
         "antd": "6.3.5",
         "qrcode.react": "4.2.0",
-        "quantum-purse-key-vault": "0.3.1",
+        "quantum-purse-key-vault": "file:../key-vault-wasm/dist",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-redux": "9.2.0",
@@ -63,6 +63,11 @@
         "webpack-dev-server": "5.2.3",
         "webpack-merge": "6.0.1"
       }
+    },
+    "../key-vault-wasm/dist": {
+      "name": "quantum-purse-key-vault",
+      "version": "0.4.0",
+      "license": "MIT"
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
@@ -2932,6 +2937,27 @@
         "@parcel/watcher-win32-x64": "2.5.1"
       }
     },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/watcher-darwin-arm64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
@@ -2944,6 +2970,255 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10.0.0"
@@ -4003,6 +4278,23 @@
       "peerDependencies": {
         "@rematch/core": ">=2"
       }
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.5.tgz",
+      "integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -8440,6 +8732,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -10186,7 +10488,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -13369,10 +13671,8 @@
       }
     },
     "node_modules/quantum-purse-key-vault": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/quantum-purse-key-vault/-/quantum-purse-key-vault-0.3.1.tgz",
-      "integrity": "sha512-nsXSFZaDjn33ToMZwKCmiHR2JoQLPTn15BfUEIIfaa916my+trHOkCvR6iHs3uIQrCLHmEH4MDF8t6vLoxNFMg==",
-      "license": "MIT"
+      "resolved": "../key-vault-wasm/dist",
+      "link": true
     },
     "node_modules/querystring-es3": {
       "version": "0.2.1",
@@ -14128,7 +14428,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@rematch/loading": "2.1.2",
     "antd": "6.3.5",
     "qrcode.react": "4.2.0",
-    "quantum-purse-key-vault": "0.3.1",
+    "quantum-purse-key-vault": "file:../key-vault-wasm/dist",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-redux": "9.2.0",

--- a/src/core/ccc-adapter/qp_signer.ts
+++ b/src/core/ccc-adapter/qp_signer.ts
@@ -1,5 +1,5 @@
 // qp_signer.ts
-// A sphincs+_based CCC compatible signer
+// A post-quantum CCC compatible signer supporting SPHINCS+ and ML-DSA-65.
 
 import {
   Signer,
@@ -12,24 +12,31 @@ import {
   BytesLike,
   Script,
   hexFrom,
+  bytesFrom,
   WitnessArgs,
   HashTypeLike
 } from "@ckb-ccc/core";
 import { QPClient } from "./qp_client";
-import { IS_MAIN_NET } from "../config";
+import { IS_MAIN_NET, MLDSA_LOCK } from "../config";
 import __wbg_init, { KeyVault, SpxVariant } from "quantum-purse-key-vault";
 import { get_ckb_tx_message_all_hash } from "../utils";
+import type { SigScheme } from "../../ui/store/models/interface";
+
+/** Size of the MldsaWitness Molecule table placed in WitnessArgs.lock (bytes). */
+const MLDSA65_WITNESS_LOCK_SIZE = 5305;
 
 export class QPSigner extends Signer {
   public accountPointer?: BytesLike;
-  protected spxLock: { codeHash: BytesLike, hashType: HashTypeLike };
+  /** Signature scheme of the currently active account. */
+  public sigScheme: SigScheme = "sphincs+";
+  protected spxLock: { codeHash: BytesLike; hashType: HashTypeLike };
   protected keyVault?: KeyVault;
   public requestPassword?: (
     resolve: (password: Uint8Array) => void,
     reject: () => void
   ) => void;
 
-  constructor(spxLockInfo: { codeHash: BytesLike, hashType: HashTypeLike }) {
+  constructor(spxLockInfo: { codeHash: BytesLike; hashType: HashTypeLike }) {
     super(new QPClient());
     this.spxLock = spxLockInfo;
   }
@@ -38,24 +45,44 @@ export class QPSigner extends Signer {
     return this.client_ as QPClient;
   }
 
-  async setAccountPointer(accPointer: BytesLike) {
-    const lockArgsList = await this.getAllLockScriptArgs();
-    if (!lockArgsList.includes(accPointer as string)) throw Error("Invalid account pointer");
+  /**
+   * Set the active account pointer, validating it exists in the DB.
+   * Also sets `sigScheme` based on which store the lock args belong to.
+   */
+  async setAccountPointer(accPointer: BytesLike, scheme?: SigScheme) {
+    if (scheme === "mldsa65") {
+      const mldsaList = await KeyVault.get_all_ml_dsa_lock_args();
+      if (!mldsaList.includes(accPointer as string))
+        throw Error("Invalid ML-DSA-65 account pointer");
+      this.sigScheme = "mldsa65";
+    } else {
+      const spxList = await this.getAllLockScriptArgs();
+      if (!spxList.includes(accPointer as string))
+        throw Error("Invalid SPHINCS+ account pointer");
+      this.sigScheme = "sphincs+";
+    }
     this.accountPointer = accPointer;
   }
 
   /**
-   * Retrieve all sphincs+ lock script arguments from all child accounts in the indexed DB.
-   * @returns An ordered array of all child key's sphincs+ lock script argument.
+   * Retrieve all SPHINCS+ lock script arguments from the indexed DB.
+   * @returns An ordered array of all SPHINCS+ lock script args.
    */
   public async getAllLockScriptArgs(): Promise<string[]> {
     return await KeyVault.get_all_sphincs_lock_args();
   }
 
   /**
-   * Initialize the key-vault instance from within Signer with a pre-determined SPHINCS variant.
+   * Retrieve all ML-DSA-65 lock script arguments from the indexed DB.
+   * @returns An ordered array of all ML-DSA-65 lock script args.
+   */
+  public async getAllMlDsaLockArgs(): Promise<string[]> {
+    return await KeyVault.get_all_ml_dsa_lock_args();
+  }
+
+  /**
+   * Initialize the key-vault instance with a pre-determined SPHINCS+ variant.
    * @param variant The SPHINCS+ parameter set to start with
-   * @returns void.
    */
   protected initKeyVaultCore(variant: SpxVariant) {
     if (this.keyVault) {
@@ -64,9 +91,16 @@ export class QPSigner extends Signer {
     this.keyVault = new KeyVault(variant);
   }
 
-  /* Wasm-bindgen module init code for Key Vault */
+  /** Wasm-bindgen module init code for Key Vault */
   protected async initKeyVaultWBG(): Promise<void> {
     await __wbg_init();
+  }
+
+  /** Returns the active lock script config based on the current sig scheme. */
+  protected get activeLock(): { codeHash: BytesLike; hashType: HashTypeLike } {
+    return this.sigScheme === "mldsa65"
+      ? { codeHash: MLDSA_LOCK.codeHash, hashType: MLDSA_LOCK.hashType }
+      : this.spxLock;
   }
 
   /** CKB network */
@@ -74,87 +108,96 @@ export class QPSigner extends Signer {
     return SignerType.CKB;
   }
 
-  /** Signature type is SPHINCS+ */
+  /** Signature type is post-quantum (SPHINCS+ or ML-DSA-65) */
   get signType(): SignerSignType {
     return SignerSignType.Unknown;
   }
 
-  /** Connect (no-op since private key must be authenticated via password each use) */
+  /** Connect (no-op — private key is authenticated per signing call) */
   async connect(): Promise<void> {
     return;
   }
 
   /** Check connection status */
   async isConnected(): Promise<boolean> {
-    return false; // never connected
+    return false;
   }
 
-  /** Get internal address */
+  /** Get internal address using the active lock script */
   async getInternalAddress(): Promise<string> {
     const lock = Script.from({
-      codeHash: this.spxLock.codeHash,
-      hashType: this.spxLock.hashType,
-      args: this.accountPointer as string
+      codeHash: this.activeLock.codeHash,
+      hashType: this.activeLock.hashType,
+      args: this.accountPointer as string,
     });
     return Address.fromScript(lock, this.client).toString();
   }
 
-  /** Get address objects 
-   * Due to the current design of Quantum Purse, this function will only return 
-   * the address object matching this.accountPointer, not all the address objects.
+  /**
+   * Get address objects for the active account.
+   * Returns only the address for the current accountPointer.
    */
   async getAddressObjs(): Promise<Address[]> {
     return [
       {
         script: Script.from({
-          codeHash: this.spxLock.codeHash,
-          hashType: this.spxLock.hashType,
-          args: this.accountPointer as string
+          codeHash: this.activeLock.codeHash,
+          hashType: this.activeLock.hashType,
+          args: this.accountPointer as string,
         }),
-        prefix: IS_MAIN_NET ? "ckb" : "ckt"
-      }
+        prefix: IS_MAIN_NET ? "ckb" : "ckt",
+      },
     ];
   }
 
-  /** Verify message */
-  async verifyMessage(message: string | BytesLike, signature: string | Signature): Promise<boolean> {
+  /** Verify message — not supported for post-quantum signers */
+  async verifyMessage(
+    _message: string | BytesLike,
+    _signature: string | Signature
+  ): Promise<boolean> {
     throw new Error("Unsupported method: verifyMessage");
   }
 
-  /** Prepare transaction */
+  /** Prepare transaction — reserves the correct witness placeholder size */
   async prepareTransaction(txLike: TransactionLike): Promise<Transaction> {
     if (!this.keyVault) throw new Error("KeyVault not initialized!");
 
     const tx = Transaction.from(txLike);
     const { script } = await this.getRecommendedAddressObj();
-    const witnessLockSizeMap = {
-      [SpxVariant.Sha2128F]: 17125,
-      [SpxVariant.Shake128F]: 17125,
-      [SpxVariant.Sha2128S]: 7893,
-      [SpxVariant.Shake128S]: 7893,
-      [SpxVariant.Sha2192F]: 35717,
-      [SpxVariant.Shake192F]: 35717,
-      [SpxVariant.Sha2192S]: 16277,
-      [SpxVariant.Shake192S]: 16277,
-      [SpxVariant.Sha2256F]: 49925,
-      [SpxVariant.Shake256F]: 49925,
-      [SpxVariant.Sha2256S]: 29861,
-      [SpxVariant.Shake256S]: 29861,
-    };
-    const variant = this.keyVault.variant;
-    const witnessLockSize = witnessLockSizeMap[variant] || 0;
+
+    let witnessLockSize: number;
+
+    if (this.sigScheme === "mldsa65") {
+      witnessLockSize = MLDSA65_WITNESS_LOCK_SIZE;
+    } else {
+      const spxSizeMap: Record<SpxVariant, number> = {
+        [SpxVariant.Sha2128F]: 17125,
+        [SpxVariant.Shake128F]: 17125,
+        [SpxVariant.Sha2128S]: 7893,
+        [SpxVariant.Shake128S]: 7893,
+        [SpxVariant.Sha2192F]: 35717,
+        [SpxVariant.Shake192F]: 35717,
+        [SpxVariant.Sha2192S]: 16277,
+        [SpxVariant.Shake192S]: 16277,
+        [SpxVariant.Sha2256F]: 49925,
+        [SpxVariant.Shake256F]: 49925,
+        [SpxVariant.Sha2256S]: 29861,
+        [SpxVariant.Shake256S]: 29861,
+      };
+      witnessLockSize = spxSizeMap[this.keyVault.variant] ?? 0;
+    }
+
     await tx.prepareSighashAllWitness(script, witnessLockSize, this.client);
     return tx;
   }
 
-  /** Sign only the transaction */
+  /** Sign only the transaction, routing to the correct scheme */
   async signOnlyTransaction(txLike: TransactionLike): Promise<Transaction> {
     let password: Uint8Array = new Uint8Array(0);
     try {
       if (!this.keyVault) throw new Error("KeyVault not initialized!");
 
       const tx = Transaction.from(txLike);
-      const message = get_ckb_tx_message_all_hash(tx); // TODO: Update when new CCC core support is released
 
       const passwordHandler = new Promise<Uint8Array>((resolve, reject) => {
         if (this.requestPassword) {
@@ -165,10 +208,30 @@ export class QPSigner extends Signer {
       });
 
       password = await passwordHandler;
-      const spxSig = await this.keyVault.sign(password, this.accountPointer as string, message);
       const position = 0;
       const witness = tx.getWitnessArgsAt(position) ?? WitnessArgs.from({});
-      witness.lock = hexFrom(spxSig);
+
+      if (this.sigScheme === "mldsa65") {
+        // ML-DSA-65: our lock script verifies blake2b("CKB-MLDSA-LOCK" || tx_hash).
+        // Pass the raw tx_hash to WASM; it constructs the signing message internally.
+        const txHashBytes = new Uint8Array(bytesFrom(tx.hash()));
+        const mldsaWitness = await this.keyVault.sign_ml_dsa(
+          password,
+          this.accountPointer as string,
+          txHashBytes
+        );
+        witness.lock = hexFrom(mldsaWitness);
+      } else {
+        // SPHINCS+: use the full CKB tx_message_all hash (RFC-0000)
+        const message = get_ckb_tx_message_all_hash(tx);
+        const spxSig = await this.keyVault.sign(
+          password,
+          this.accountPointer as string,
+          message
+        );
+        witness.lock = hexFrom(spxSig);
+      }
+
       tx.setWitnessArgsAt(position, witness);
       return tx;
     } catch (error: any) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -25,6 +25,34 @@ export const SPHINCSPLUS_LOCK = IS_MAIN_NET
     depType: "code",
   };
 
+// ML-DSA-65 (FIPS 204) Lock Script contract
+// Testnet type_id: deployed via ckb-mldsa-lock (github.com/toastmanAu/ckb-mldsa-lock)
+// Mainnet: not yet deployed — use testnet config as placeholder until mainnet launch.
+export const MLDSA_LOCK = IS_MAIN_NET
+  ? {
+    // TODO: replace with mainnet deployment once audited and deployed
+    codeHash:
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+    hashType: "type" as const,
+    outPoint: {
+      txHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      index: "0x0",
+    },
+    depType: "code" as const,
+  } : {
+    // type_id — stable across contract upgrades
+    codeHash:
+      "0x8984f4230ded4ac1f5efee2b67fef45fcda08bd6344c133a2f378e2f469d310d",
+    hashType: "type" as const,
+    outPoint: {
+      txHash:
+        "0xba4a6560ef719b24d170bf678611b25b799c56e6a80f18ce9c79e9561085cba7",
+      index: "0x0",
+    },
+    depType: "code" as const,
+  };
+
 // Nervos DAO Type Script contract
 export const NERVOS_DAO = IS_MAIN_NET
   ? {

--- a/src/core/quantum_purse.ts
+++ b/src/core/quantum_purse.ts
@@ -322,16 +322,6 @@ export default class QuantumPurse extends QPSigner {
     };
   }
 
-  /**
-   * Gets the blockchain address.
-   * @param spxLockArgs - The sphincs+ lock script arguments.
-   * @returns The CKB address as a string.
-   * @throws Error if no account pointer is set by default (see `getLockScript` for details).
-   */
-  public getAddress(spxLockArgs?: BytesLike): string {
-    const lock = this.getLockScript(spxLockArgs);
-    return Address.fromScript(lock, this.client).toString();
-  }
 
   /**
    * Gets account available (transferable) balance via light client protocol.

--- a/src/core/quantum_purse.ts
+++ b/src/core/quantum_purse.ts
@@ -1,5 +1,6 @@
 // QuantumPurse.ts
-import { IS_MAIN_NET, SPHINCSPLUS_LOCK, NERVOS_DAO } from "./config";
+import { IS_MAIN_NET, SPHINCSPLUS_LOCK, MLDSA_LOCK, NERVOS_DAO } from "./config";
+import type { IAccount, SigScheme } from "../ui/store/models/interface";
 import { KeyVault, Util as KeyVaultUtil, SpxVariant } from "quantum-purse-key-vault";
 import { randomSecretKey, LightClientSetScriptsCommand, ScriptStatus } from "@nervosnetwork/ckb-light-client-js";
 import testnetConfig from "../../light-client/network.test.toml";
@@ -419,6 +420,74 @@ export default class QuantumPurse extends QPSigner {
     } finally {
       password.fill(0);
     }
+  }
+
+  /**
+   * Generates a new ML-DSA-65 account derived from the wallet master seed.
+   *
+   * The keypair is never stored — only the 36-byte lock args are persisted in IndexedDB.
+   * On each signing call the secret key is re-derived from the master seed via HKDF.
+   *
+   * @param password - The wallet password (will be zeroed after use).
+   * @returns The lock args hex string and the CKB address for the new ML-DSA-65 account.
+   * @throws Error if the master seed is not found or decryption fails.
+   */
+  public async genMlDsa65Account(
+    password: Uint8Array
+  ): Promise<{ lockArgs: string; address: string }> {
+    try {
+      if (!this.keyVault) throw new Error("KeyVault not initialized!");
+
+      const lockArgs = await this.keyVault.gen_new_ml_dsa_account(password);
+
+      // Build the CKB address using the ML-DSA-65 lock script
+      const lock = {
+        codeHash: MLDSA_LOCK.codeHash,
+        hashType: MLDSA_LOCK.hashType,
+        args: lockArgs as Hex,
+      };
+      const address = this.getAddress(lockArgs as Hex, "mldsa65");
+
+      // Register the new lock script with the light client for balance tracking
+      const existingCount = (await this.getAllMlDsaLockArgs()).length;
+      await this.setSellectiveSyncFilterInternal(lockArgs as Hex, existingCount <= 1);
+
+      return { lockArgs, address };
+    } finally {
+      password.fill(0);
+    }
+  }
+
+  /**
+   * Returns the CKB address for a given lock args and signature scheme.
+   * @param lockArgs - The lock script args (hex string).
+   * @param scheme - The signature scheme ("sphincs+" or "mldsa65").
+   */
+  public getAddress(lockArgs?: BytesLike, scheme: SigScheme = "sphincs+"): string {
+    const lockInfo = scheme === "mldsa65" ? MLDSA_LOCK : SPHINCSPLUS_LOCK;
+    const lock = this.getLockScriptForScheme(lockArgs, lockInfo);
+    const addr = Address.fromScript(lock as any, this.client);
+    return addr.toString();
+  }
+
+  /**
+   * Retrieve all ML-DSA-65 lock script args stored in IndexedDB.
+   */
+  public async getAllMlDsaLockArgs(): Promise<string[]> {
+    return await KeyVault.get_all_ml_dsa_lock_args();
+  }
+
+  // ── internal helpers ──────────────────────────────────────────────────────
+
+  private getLockScriptForScheme(
+    lockArgs: BytesLike | undefined,
+    lockInfo: { codeHash: string; hashType: string }
+  ) {
+    return {
+      codeHash: lockInfo.codeHash,
+      hashType: lockInfo.hashType,
+      args: lockArgs !== undefined ? lockArgs : (this.accountPointer as string),
+    };
   }
 
   /**

--- a/src/core/quantum_purse.ts
+++ b/src/core/quantum_purse.ts
@@ -608,6 +608,87 @@ export default class QuantumPurse extends QPSigner {
   }
 
   /**
+   * Derives ML-DSA-65 lock args in a batch without persisting them — used for
+   * account discovery during wallet import.
+   */
+  public async genMlDsa65AccountInBatch(
+    password: Uint8Array,
+    startIndex: number,
+    count: number
+  ): Promise<string[]> {
+    try {
+      if (!this.keyVault) throw new Error("KeyVault not initialized!");
+      return await this.keyVault.try_gen_ml_dsa_account_batch(password, startIndex, count);
+    } finally {
+      password.fill(0);
+    }
+  }
+
+  /**
+   * Derives and persists `count` ML-DSA-65 accounts from index 0, registering
+   * each with the light client for balance tracking.
+   */
+  public async recoverMlDsaAccounts(password: Uint8Array, count: number): Promise<void> {
+    try {
+      if (!this.keyVault) throw new Error("KeyVault not initialized!");
+      const lockArgsList = await this.keyVault.recover_ml_dsa_accounts(password, count) as Hex[];
+
+      if (!this.hasClientStarted) {
+        logger("error", "Light client has not initialized");
+        return;
+      }
+
+      const startBlocksPromises = lockArgsList.map(async (lockArgs) => {
+        const lock = {
+          codeHash: MLDSA_LOCK.codeHash,
+          hashType: MLDSA_LOCK.hashType,
+          args: lockArgs as Hex,
+        };
+        const searchKey: ClientIndexerSearchKeyLike = {
+          scriptType: "lock",
+          script: lock,
+          scriptSearchMode: "prefix",
+        };
+
+        let startBlock = BigInt(0);
+        const response = await this.client.getTransactions(searchKey, "asc", 1);
+        if (response.transactions && response.transactions.length > 0) {
+          startBlock = response.transactions[0].blockNumber - BigInt(1);
+        }
+        return startBlock;
+      });
+
+      const startBlocks = await Promise.all(startBlocksPromises);
+      await this.setSellectiveSyncFilter(lockArgsList, startBlocks, LightClientSetScriptsCommand.All);
+    } finally {
+      password.fill(0);
+    }
+  }
+
+  /**
+   * Gets available balance for an ML-DSA-65 account via the light client.
+   */
+  public async getMlDsaBalance(lockArgs: Hex): Promise<bigint> {
+    if (!this.hasClientStarted) {
+      logger("error", "Light client has not initialized");
+      return Promise.resolve(BigInt(0));
+    }
+
+    const lock = {
+      codeHash: MLDSA_LOCK.codeHash,
+      hashType: MLDSA_LOCK.hashType,
+      args: lockArgs,
+    };
+    const searchKey: ClientIndexerSearchKeyLike = {
+      scriptType: "lock",
+      script: lock,
+      scriptSearchMode: "prefix",
+      filter: { outputDataLenRange: [0, 1] },
+    };
+    return await this.client.getCellsCapacity(searchKey);
+  }
+
+  /**
    * CKB transfer from the current Quantum Purse address.
    *
    * @param to - The recipient's address.

--- a/src/ui/components/account-item/account_item.tsx
+++ b/src/ui/components/account-item/account_item.tsx
@@ -30,6 +30,7 @@ interface AccountItemProps extends React.HTMLAttributes<HTMLLIElement> {
   address: string;
   name: string;
   spxLockArgs: string;
+  scheme?: "sphincs+" | "mldsa65";
   hasTools?: boolean;
   copyable?: boolean;
   showBalance?: boolean;
@@ -40,6 +41,7 @@ export const AccountItem: React.FC<AccountItemProps> = ({
   address,
   name,
   spxLockArgs,
+  scheme = "sphincs+",
   hasTools = true,
   copyable = true,
   showBalance = false,
@@ -82,7 +84,7 @@ export const AccountItem: React.FC<AccountItemProps> = ({
       <li {...props} className={cx(styles.accountItem)}>
         <div
           className="account-info"
-          onClick={() => (!isActive && isWalletPage) && dispatch.wallet.switchAccount({ spxLockArgs })}
+          onClick={() => (!isActive && isWalletPage) && dispatch.wallet.switchAccount({ spxLockArgs, scheme })}
         >
           <p className="name">
             {name}{" "}

--- a/src/ui/components/sphincs-param-set/param_selector.tsx
+++ b/src/ui/components/sphincs-param-set/param_selector.tsx
@@ -1,10 +1,58 @@
-import { Form, Select, Tooltip } from "antd";
+import { Cascader, Form, Tooltip } from "antd";
 import { QuestionCircleOutlined } from "@ant-design/icons";
 import { SpxVariant } from "../../../core/quantum_purse";
 import { useLocation } from "react-router-dom";
 import styles from './param_selector.module.scss';
 
+const WALLET_TYPE_OPTIONS = [
+  {
+    value: "mldsa65",
+    label: "ML-DSA-65 (FIPS 204)",
+    children: [
+      { value: "mldsa65", label: "ML-DSA-65 — Lattice-based, compact signatures" },
+    ],
+  },
+  {
+    value: "sphincs+",
+    label: "SPHINCS+ (FIPS 205)",
+    children: [
+      {
+        value: "128",
+        label: "128-bit security (36-word mnemonic)",
+        children: [
+          { value: SpxVariant.Sha2128S, label: "SHA2_128s — recommended" },
+          { value: SpxVariant.Sha2128F, label: "SHA2_128f — fast signing" },
+          { value: SpxVariant.Shake128S, label: "SHAKE_128s" },
+          { value: SpxVariant.Shake128F, label: "SHAKE_128f" },
+        ],
+      },
+      {
+        value: "192",
+        label: "192-bit security (54-word mnemonic)",
+        children: [
+          { value: SpxVariant.Sha2192S, label: "SHA2_192s" },
+          { value: SpxVariant.Sha2192F, label: "SHA2_192f" },
+          { value: SpxVariant.Shake192S, label: "SHAKE_192s" },
+          { value: SpxVariant.Shake192F, label: "SHAKE_192f" },
+        ],
+      },
+      {
+        value: "256",
+        label: "256-bit security (72-word mnemonic)",
+        children: [
+          { value: SpxVariant.Sha2256S, label: "SHA2_256s" },
+          { value: SpxVariant.Sha2256F, label: "SHA2_256f" },
+          { value: SpxVariant.Shake256S, label: "SHAKE_256s" },
+          { value: SpxVariant.Shake256F, label: "SHAKE_256f" },
+        ],
+      },
+    ],
+  },
+];
+
 const ParamsetSelector: React.FC = () => {
+  const isImport = useLocation().pathname === "/import-wallet";
+
   return (
     <Form.Item
       className={styles.paramsetSelector}
@@ -13,9 +61,9 @@ const ParamsetSelector: React.FC = () => {
           Wallet Type
           <Tooltip
             title={
-              useLocation().pathname === "/import-wallet"
-                ? "What SPHINCS+ parameter set did you back up with the input seed phrase?"
-                : "There are 12 SPHINCS+ parameter sets in total, each will determine your wallet type. Sha2_256s is recommended if you have no reference!"
+              isImport
+                ? "Select the scheme and parameter set you used when creating this wallet."
+                : "Choose your signature scheme. ML-DSA-65 is a lattice-based NIST standard with compact signatures. SPHINCS+ is a hash-based alternative with 12 parameter variants."
             }
           >
             <QuestionCircleOutlined style={{ marginLeft: 8 }} />
@@ -23,34 +71,18 @@ const ParamsetSelector: React.FC = () => {
         </span>
       }
       name="parameterSet"
-      rules={[{ required: true, message: "" }]}
+      rules={[{ required: true, message: "Please select a wallet type" }]}
+      // Cascader returns an array — normalise to the leaf value for the rest of the form
+      getValueFromEvent={(val: (string | number)[]) => val ? val[val.length - 1] : undefined}
     >
-      <Select
+      <Cascader
         size="large"
-        placeholder="Select a wallet type"
-      >
-        <Select.OptGroup label="— ML-DSA-65 (FIPS 204) —">
-          <Select.Option value="mldsa65">ML-DSA-65 ✦ Lattice-based, compact signatures</Select.Option>
-        </Select.OptGroup>
-        <Select.OptGroup label="— SPHINCS+ (FIPS 205) — 128-bit | 36-word mnemonic">
-          <Select.Option value={SpxVariant.Sha2128S}>SHA2_128s</Select.Option>
-          <Select.Option value={SpxVariant.Sha2128F}>SHA2_128f</Select.Option>
-          <Select.Option value={SpxVariant.Shake128S}>SHAKE_128s</Select.Option>
-          <Select.Option value={SpxVariant.Shake128F}>SHAKE_128f</Select.Option>
-        </Select.OptGroup>
-        <Select.OptGroup label="SPHINCS+ — 192-bit | 54-word mnemonic">
-          <Select.Option value={SpxVariant.Sha2192S}>SHA2_192s</Select.Option>
-          <Select.Option value={SpxVariant.Sha2192F}>SHA2_192f</Select.Option>
-          <Select.Option value={SpxVariant.Shake192S}>SHAKE_192s</Select.Option>
-          <Select.Option value={SpxVariant.Shake192F}>SHAKE_192f</Select.Option>
-        </Select.OptGroup>
-        <Select.OptGroup label="SPHINCS+ — 256-bit | 72-word mnemonic">
-          <Select.Option value={SpxVariant.Sha2256S}>SHA2_256s</Select.Option>
-          <Select.Option value={SpxVariant.Sha2256F}>SHA2_256f</Select.Option>
-          <Select.Option value={SpxVariant.Shake256S}>SHAKE_256s</Select.Option>
-          <Select.Option value={SpxVariant.Shake256F}>SHAKE_256f</Select.Option>
-        </Select.OptGroup>
-      </Select>
+        placeholder="Select scheme → variant"
+        options={WALLET_TYPE_OPTIONS}
+        expandTrigger="hover"
+        displayRender={(labels) => labels[labels.length - 1]}
+        style={{ width: "100%" }}
+      />
     </Form.Item>
   );
 };

--- a/src/ui/components/sphincs-param-set/param_selector.tsx
+++ b/src/ui/components/sphincs-param-set/param_selector.tsx
@@ -1,58 +1,10 @@
-import { Cascader, Form, Tooltip } from "antd";
+import { Form, Select, Tooltip } from "antd";
 import { QuestionCircleOutlined } from "@ant-design/icons";
 import { SpxVariant } from "../../../core/quantum_purse";
 import { useLocation } from "react-router-dom";
 import styles from './param_selector.module.scss';
 
-const WALLET_TYPE_OPTIONS = [
-  {
-    value: "mldsa65",
-    label: "ML-DSA-65 (FIPS 204)",
-    children: [
-      { value: "mldsa65", label: "ML-DSA-65 — Lattice-based, compact signatures" },
-    ],
-  },
-  {
-    value: "sphincs+",
-    label: "SPHINCS+ (FIPS 205)",
-    children: [
-      {
-        value: "128",
-        label: "128-bit security (36-word mnemonic)",
-        children: [
-          { value: SpxVariant.Sha2128S, label: "SHA2_128s — recommended" },
-          { value: SpxVariant.Sha2128F, label: "SHA2_128f — fast signing" },
-          { value: SpxVariant.Shake128S, label: "SHAKE_128s" },
-          { value: SpxVariant.Shake128F, label: "SHAKE_128f" },
-        ],
-      },
-      {
-        value: "192",
-        label: "192-bit security (54-word mnemonic)",
-        children: [
-          { value: SpxVariant.Sha2192S, label: "SHA2_192s" },
-          { value: SpxVariant.Sha2192F, label: "SHA2_192f" },
-          { value: SpxVariant.Shake192S, label: "SHAKE_192s" },
-          { value: SpxVariant.Shake192F, label: "SHAKE_192f" },
-        ],
-      },
-      {
-        value: "256",
-        label: "256-bit security (72-word mnemonic)",
-        children: [
-          { value: SpxVariant.Sha2256S, label: "SHA2_256s" },
-          { value: SpxVariant.Sha2256F, label: "SHA2_256f" },
-          { value: SpxVariant.Shake256S, label: "SHAKE_256s" },
-          { value: SpxVariant.Shake256F, label: "SHAKE_256f" },
-        ],
-      },
-    ],
-  },
-];
-
 const ParamsetSelector: React.FC = () => {
-  const isImport = useLocation().pathname === "/import-wallet";
-
   return (
     <Form.Item
       className={styles.paramsetSelector}
@@ -61,9 +13,9 @@ const ParamsetSelector: React.FC = () => {
           Wallet Type
           <Tooltip
             title={
-              isImport
-                ? "Select the scheme and parameter set you used when creating this wallet."
-                : "Choose your signature scheme. ML-DSA-65 is a lattice-based NIST standard with compact signatures. SPHINCS+ is a hash-based alternative with 12 parameter variants."
+              useLocation().pathname === "/import-wallet"
+                ? "What SPHINCS+ parameter set did you back up with the input seed phrase?"
+                : "There are 12 SPHINCS+ parameter sets in total, each will determine your wallet type. Sha2_256s is recommended if you have no reference!"
             }
           >
             <QuestionCircleOutlined style={{ marginLeft: 8 }} />
@@ -71,18 +23,34 @@ const ParamsetSelector: React.FC = () => {
         </span>
       }
       name="parameterSet"
-      rules={[{ required: true, message: "Please select a wallet type" }]}
-      // Cascader returns an array — normalise to the leaf value for the rest of the form
-      getValueFromEvent={(val: (string | number)[]) => val ? val[val.length - 1] : undefined}
+      rules={[{ required: true, message: "" }]}
     >
-      <Cascader
+      <Select
         size="large"
-        placeholder="Select scheme → variant"
-        options={WALLET_TYPE_OPTIONS}
-        expandTrigger="hover"
-        displayRender={(labels) => labels[labels.length - 1]}
-        style={{ width: "100%" }}
-      />
+        placeholder="Select a wallet type"
+      >
+        <Select.OptGroup label="— ML-DSA-65 (FIPS 204) —">
+          <Select.Option value="mldsa65">ML-DSA-65 ✦ Lattice-based, compact signatures</Select.Option>
+        </Select.OptGroup>
+        <Select.OptGroup label="— SPHINCS+ (FIPS 205) — 128-bit | 36-word mnemonic">
+          <Select.Option value={SpxVariant.Sha2128S}>SHA2_128s</Select.Option>
+          <Select.Option value={SpxVariant.Sha2128F}>SHA2_128f</Select.Option>
+          <Select.Option value={SpxVariant.Shake128S}>SHAKE_128s</Select.Option>
+          <Select.Option value={SpxVariant.Shake128F}>SHAKE_128f</Select.Option>
+        </Select.OptGroup>
+        <Select.OptGroup label="SPHINCS+ — 192-bit | 54-word mnemonic">
+          <Select.Option value={SpxVariant.Sha2192S}>SHA2_192s</Select.Option>
+          <Select.Option value={SpxVariant.Sha2192F}>SHA2_192f</Select.Option>
+          <Select.Option value={SpxVariant.Shake192S}>SHAKE_192s</Select.Option>
+          <Select.Option value={SpxVariant.Shake192F}>SHAKE_192f</Select.Option>
+        </Select.OptGroup>
+        <Select.OptGroup label="SPHINCS+ — 256-bit | 72-word mnemonic">
+          <Select.Option value={SpxVariant.Sha2256S}>SHA2_256s</Select.Option>
+          <Select.Option value={SpxVariant.Sha2256F}>SHA2_256f</Select.Option>
+          <Select.Option value={SpxVariant.Shake256S}>SHAKE_256s</Select.Option>
+          <Select.Option value={SpxVariant.Shake256F}>SHAKE_256f</Select.Option>
+        </Select.OptGroup>
+      </Select>
     </Form.Item>
   );
 };

--- a/src/ui/components/sphincs-param-set/param_selector.tsx
+++ b/src/ui/components/sphincs-param-set/param_selector.tsx
@@ -27,21 +27,24 @@ const ParamsetSelector: React.FC = () => {
     >
       <Select
         size="large"
-        placeholder="Select a SPHINCS+ variant"
+        placeholder="Select a wallet type"
       >
-        <Select.OptGroup label="128-bit | 36-word mnemonic">
+        <Select.OptGroup label="— ML-DSA-65 (FIPS 204) —">
+          <Select.Option value="mldsa65">ML-DSA-65 ✦ Lattice-based, compact signatures</Select.Option>
+        </Select.OptGroup>
+        <Select.OptGroup label="— SPHINCS+ (FIPS 205) — 128-bit | 36-word mnemonic">
           <Select.Option value={SpxVariant.Sha2128S}>SHA2_128s</Select.Option>
           <Select.Option value={SpxVariant.Sha2128F}>SHA2_128f</Select.Option>
           <Select.Option value={SpxVariant.Shake128S}>SHAKE_128s</Select.Option>
           <Select.Option value={SpxVariant.Shake128F}>SHAKE_128f</Select.Option>
         </Select.OptGroup>
-        <Select.OptGroup label="192-bit | 54-word mnemonic">
+        <Select.OptGroup label="SPHINCS+ — 192-bit | 54-word mnemonic">
           <Select.Option value={SpxVariant.Sha2192S}>SHA2_192s</Select.Option>
           <Select.Option value={SpxVariant.Sha2192F}>SHA2_192f</Select.Option>
           <Select.Option value={SpxVariant.Shake192S}>SHAKE_192s</Select.Option>
           <Select.Option value={SpxVariant.Shake192F}>SHAKE_192f</Select.Option>
         </Select.OptGroup>
-        <Select.OptGroup label="256-bit | 72-word mnemonic">
+        <Select.OptGroup label="SPHINCS+ — 256-bit | 72-word mnemonic">
           <Select.Option value={SpxVariant.Sha2256S}>SHA2_256s</Select.Option>
           <Select.Option value={SpxVariant.Sha2256F}>SHA2_256f</Select.Option>
           <Select.Option value={SpxVariant.Shake256S}>SHAKE_256s</Select.Option>

--- a/src/ui/pages/CreateWallet/CreateWallet.tsx
+++ b/src/ui/pages/CreateWallet/CreateWallet.tsx
@@ -1,5 +1,5 @@
 import { KeyOutlined, LoadingOutlined, LockOutlined, EyeInvisibleOutlined, EyeOutlined } from "@ant-design/icons";
-import { Button, Checkbox, Flex, Form, Modal } from "antd";
+import { Button, Checkbox, Flex, Form, Modal, Select } from "antd";
 import React, {
   createContext,
   useContext,
@@ -281,9 +281,9 @@ export const StepCreatePassword: React.FC = () => {
       const isMlDsa = parameterSet === "mldsa65";
 
       if (isMlDsa) {
-        // KeyVault instance is required even for ML-DSA — initialise with a
-        // default SPHINCS+ variant so the object exists; it won't be used for signing.
-        QuantumPurse.getInstance().initKeyVault(SpxVariant.Sha2128S);
+        const spxVariant = formValues.spxVariant;
+        QuantumPurse.getInstance().initKeyVault(spxVariant);
+        await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, spxVariant.toString());
       } else if (parameterSet) {
         QuantumPurse.getInstance().initKeyVault(parameterSet);
         await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, parameterSet.toString());
@@ -339,6 +339,40 @@ export const StepCreatePassword: React.FC = () => {
       >
         
         <ParamSetSelectorForm />
+
+        {parameterSet === "mldsa65" && (
+          <Form.Item
+            name="spxVariant"
+            label={
+              <span style={{ color: 'var(--gray-01)' }}>
+                SPHINCS+ Variant (for key storage)
+              </span>
+            }
+            rules={[{ required: true, message: "Please select a SPHINCS+ variant" }]}
+            tooltip="ML-DSA uses the same master seed as SPHINCS+. Pick the variant your key vault will use — you'll need to note it alongside your mnemonic."
+          >
+            <Select size="large" placeholder="Select a SPHINCS+ variant">
+              <Select.OptGroup label="128-bit | 36-word mnemonic">
+                <Select.Option value={SpxVariant.Sha2128S}>SHA2_128s — recommended</Select.Option>
+                <Select.Option value={SpxVariant.Sha2128F}>SHA2_128f</Select.Option>
+                <Select.Option value={SpxVariant.Shake128S}>SHAKE_128s</Select.Option>
+                <Select.Option value={SpxVariant.Shake128F}>SHAKE_128f</Select.Option>
+              </Select.OptGroup>
+              <Select.OptGroup label="192-bit | 54-word mnemonic">
+                <Select.Option value={SpxVariant.Sha2192S}>SHA2_192s</Select.Option>
+                <Select.Option value={SpxVariant.Sha2192F}>SHA2_192f</Select.Option>
+                <Select.Option value={SpxVariant.Shake192S}>SHAKE_192s</Select.Option>
+                <Select.Option value={SpxVariant.Shake192F}>SHAKE_192f</Select.Option>
+              </Select.OptGroup>
+              <Select.OptGroup label="256-bit | 72-word mnemonic">
+                <Select.Option value={SpxVariant.Sha2256S}>SHA2_256s</Select.Option>
+                <Select.Option value={SpxVariant.Sha2256F}>SHA2_256f</Select.Option>
+                <Select.Option value={SpxVariant.Shake256S}>SHAKE_256s</Select.Option>
+                <Select.Option value={SpxVariant.Shake256F}>SHAKE_256f</Select.Option>
+              </Select.OptGroup>
+            </Select>
+          </Form.Item>
+        )}
 
         <div style={{ marginBottom: '1.6rem' }}>
           <label

--- a/src/ui/pages/CreateWallet/CreateWallet.tsx
+++ b/src/ui/pages/CreateWallet/CreateWallet.tsx
@@ -278,23 +278,24 @@ export const StepCreatePassword: React.FC = () => {
     try {
       const parameterSet = formValues.parameterSet;
 
-      if (parameterSet) {
+      const isMlDsa = parameterSet === "mldsa65";
+
+      if (!isMlDsa && parameterSet) {
         QuantumPurse.getInstance().initKeyVault(parameterSet);
-        // store chosen param set to storage, so wallet type retains when refreshed
         await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, parameterSet.toString());
       }
 
-      // Convert to bytes immediately to allow referencing throughout the call stack
-      // each function call to key-vault clears the password bytes buffer, here it is firstly
-      // used to create the wallet then to export the SRP. So clone password for the second call
       passwordBytes = utf8ToBytes(passwordInputRef.current.value);
       clonedPasswordBytes = passwordBytes.slice();
 
-      // input cleaning. Either success or throw.
       passwordInputRef.current.value = '';
       confirmPasswordInputRef.current.value = '';
 
-      await dispatch.wallet.createWallet({ password: passwordBytes });
+      if (isMlDsa) {
+        await dispatch.wallet.createWalletMlDsa({ password: passwordBytes });
+      } else {
+        await dispatch.wallet.createWallet({ password: passwordBytes });
+      }
       srpRef.current = await QuantumPurse.getInstance().exportSeedPhrase(clonedPasswordBytes);
       setSrpRevealed(true);
       next();
@@ -482,7 +483,9 @@ const StepSecureSRP: React.FC = () => {
       title={"Secure Secret Recovery Phrase"}
       description={
         srpRef.current
-          ? "WARNING! Never copy or screenshot!\nOnly handwrite to backup your mnemonic phrase! \n Backup too your chosen SPHINCS+ variant [" + SpxVariant[Number(QuantumPurse.getInstance().getSphincsPlusParamSet())] + "]!"
+          ? QuantumPurse.getInstance().getSphincsPlusParamSet()
+            ? "WARNING! Never copy or screenshot!\nOnly handwrite to backup your mnemonic phrase! \n Backup too your chosen SPHINCS+ variant [" + SpxVariant[Number(QuantumPurse.getInstance().getSphincsPlusParamSet())] + "]!"
+            : "WARNING! Never copy or screenshot!\nOnly handwrite to backup your mnemonic phrase!\nThis wallet uses ML-DSA-65 — no variant to note, just the mnemonic."
           : "Your wallet creation process has been interrupted. Please enter your password to reveal your SRP then follow through the process or reset and start again."
       }
       exportSrpHandler={exportSrpHandler}

--- a/src/ui/pages/CreateWallet/CreateWallet.tsx
+++ b/src/ui/pages/CreateWallet/CreateWallet.tsx
@@ -280,7 +280,11 @@ export const StepCreatePassword: React.FC = () => {
 
       const isMlDsa = parameterSet === "mldsa65";
 
-      if (!isMlDsa && parameterSet) {
+      if (isMlDsa) {
+        // KeyVault instance is required even for ML-DSA — initialise with a
+        // default SPHINCS+ variant so the object exists; it won't be used for signing.
+        QuantumPurse.getInstance().initKeyVault(SpxVariant.Sha2128S);
+      } else if (parameterSet) {
         QuantumPurse.getInstance().initKeyVault(parameterSet);
         await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, parameterSet.toString());
       }

--- a/src/ui/pages/ImportWallet/ImportWallet.tsx
+++ b/src/ui/pages/ImportWallet/ImportWallet.tsx
@@ -6,6 +6,7 @@ import {
   Form,
   FormInstance,
   Modal,
+  Select,
   Tabs,
 } from "antd";
 import React, {
@@ -182,6 +183,40 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
       <h2>Wallet Type & Password</h2>
 
       <ParamSetSelector />
+
+      {parameterSet === "mldsa65" && (
+        <Form.Item
+          name="spxVariant"
+          label={
+            <span style={{ color: 'var(--gray-01)' }}>
+              SPHINCS+ Variant (for key storage)
+            </span>
+          }
+          rules={[{ required: true, message: "Please select the SPHINCS+ variant you used" }]}
+          tooltip="Select the SPHINCS+ variant you chose when creating this wallet — required to reconstruct the key vault."
+        >
+          <Select size="large" placeholder="Select the SPHINCS+ variant you used">
+            <Select.OptGroup label="128-bit | 36-word mnemonic">
+              <Select.Option value={SpxVariant.Sha2128S}>SHA2_128s</Select.Option>
+              <Select.Option value={SpxVariant.Sha2128F}>SHA2_128f</Select.Option>
+              <Select.Option value={SpxVariant.Shake128S}>SHAKE_128s</Select.Option>
+              <Select.Option value={SpxVariant.Shake128F}>SHAKE_128f</Select.Option>
+            </Select.OptGroup>
+            <Select.OptGroup label="192-bit | 54-word mnemonic">
+              <Select.Option value={SpxVariant.Sha2192S}>SHA2_192s</Select.Option>
+              <Select.Option value={SpxVariant.Sha2192F}>SHA2_192f</Select.Option>
+              <Select.Option value={SpxVariant.Shake192S}>SHAKE_192s</Select.Option>
+              <Select.Option value={SpxVariant.Shake192F}>SHAKE_192f</Select.Option>
+            </Select.OptGroup>
+            <Select.OptGroup label="256-bit | 72-word mnemonic">
+              <Select.Option value={SpxVariant.Sha2256S}>SHA2_256s</Select.Option>
+              <Select.Option value={SpxVariant.Sha2256F}>SHA2_256f</Select.Option>
+              <Select.Option value={SpxVariant.Shake256S}>SHAKE_256s</Select.Option>
+              <Select.Option value={SpxVariant.Shake256F}>SHAKE_256f</Select.Option>
+            </Select.OptGroup>
+          </Select>
+        </Form.Item>
+      )}
 
       <div style={{ marginBottom: '1.6rem' }}>
         <label
@@ -409,34 +444,35 @@ const ImportWalletContent: React.FC = () => {
     };
   }, []);
 
-  const onFinish = async ({ parameterSet }: { parameterSet: SpxVariant }) => {
+  const onFinish = async (formValues: any) => {
     if (!passwordInputRef.current || !srpInputRef.current || !confirmPasswordInputRef.current) return;
 
-    QuantumPurse.getInstance().initKeyVault(parameterSet);
-    // store chosen param set to storage, so wallet type retains when refreshed
-    await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, parameterSet.toString());
+    const { parameterSet, spxVariant } = formValues;
+    const isMlDsa = parameterSet === "mldsa65";
+    const keyVaultVariant = isMlDsa ? spxVariant : parameterSet;
+
+    QuantumPurse.getInstance().initKeyVault(keyVaultVariant);
+    await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, keyVaultVariant.toString());
 
     let srpBytes: Uint8Array = new Uint8Array(0);
     let passwordBytes: Uint8Array = new Uint8Array(0);
     try {
-      // Convert to bytes immediately to allow referencing throughout the call stack
-      // if fail, inputs are highly not valid, so no clean up needed -> let users edit inputs again.
       srpBytes = utf8ToBytes(srpInputRef.current.value);
       passwordBytes = utf8ToBytes(passwordInputRef.current.value);
 
-      // if the following line successes, clear the input references. If not, allow to edit inputs again.
-      await dispatch.wallet.importWallet({ srp: srpBytes, password: passwordBytes });
+      if (isMlDsa) {
+        await dispatch.wallet.importWalletMlDsa({ srp: srpBytes, password: passwordBytes });
+      } else {
+        await dispatch.wallet.importWallet({ srp: srpBytes, password: passwordBytes });
+      }
 
-      // input cleaning. Either success or throw.
       srpInputRef.current.value = '';
       passwordInputRef.current.value = '';
       confirmPasswordInputRef.current.value = '';
 
-      // success, procees to load the wallet
       await dispatch.wallet.init({});
       await dispatch.wallet.loadCurrentAccount({});
     } catch (error) {
-
       Modal.error({
         title: 'Import Wallet Failed',
         content: (
@@ -450,7 +486,6 @@ const ImportWalletContent: React.FC = () => {
         maskTransitionName: '',
       });
       return;
-
     } finally {
       srpBytes.fill(0);
       passwordBytes.fill(0);

--- a/src/ui/pages/Settings/Accounts/Accounts.tsx
+++ b/src/ui/pages/Settings/Accounts/Accounts.tsx
@@ -81,7 +81,7 @@ const Accounts: React.FC = () => {
 
     return (
       <ul className="account-container">
-        {filteredAccounts.map(({ address, name, spxLockArgs }, index) => (
+        {filteredAccounts.map(({ address, name, spxLockArgs, scheme }, index) => (
           <React.Fragment key={spxLockArgs}>
             {index > 0 && (
               <Divider className="divider" key={`divider-${index}`} />
@@ -91,6 +91,7 @@ const Accounts: React.FC = () => {
               address={address!}
               name={name}
               spxLockArgs={spxLockArgs}
+              scheme={scheme}
               isLoading={loadingSwitchAccount}
             />
           </React.Fragment>

--- a/src/ui/pages/Settings/Accounts/Accounts.tsx
+++ b/src/ui/pages/Settings/Accounts/Accounts.tsx
@@ -5,9 +5,10 @@ import {
   Flex,
   Input,
   Modal,
+  Segmented,
   Spin,
 } from "antd";
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   Authentication,
@@ -15,6 +16,7 @@ import {
 } from "../../../components";
 import { useAccountSearch } from "../../../hooks/useAccountSearch";
 import { Dispatch, RootState } from "../../../store";
+import { SigScheme } from "../../../store/models/interface";
 import { cx, formatError } from "../../../utils/methods";
 import styles from "./Accounts.module.scss";
 import { AccountItem } from "../../../components/account-item/account_item";
@@ -24,6 +26,7 @@ const Accounts: React.FC = () => {
   const wallet = useSelector((state: RootState) => state.wallet);
   const {
     createAccount: loadingCreateAccount,
+    createMlDsaAccount: loadingCreateMlDsaAccount,
     loadAccounts: loadingLoadAccounts,
     switchAccount: loadingSwitchAccount,
   } = useSelector((state: RootState) => state.loading.effects.wallet);
@@ -32,10 +35,17 @@ const Accounts: React.FC = () => {
     useAccountSearch(wallet.accounts);
 
   const authenticationRef = useRef<AuthenticationRef>(null);
+  const [selectedScheme, setSelectedScheme] = useState<SigScheme>("sphincs+");
+
+  const isCreating = loadingCreateAccount || loadingCreateMlDsaAccount;
 
   const createAccountHandler = async (password: Uint8Array) => {
     try {
-      await dispatch.wallet.createAccount({ password });
+      if (selectedScheme === "mldsa65") {
+        await dispatch.wallet.createMlDsaAccount({ password });
+      } else {
+        await dispatch.wallet.createAccount({ password });
+      }
     } catch (error) {
       Modal.error({
         title: 'Failed to Create Account',
@@ -97,7 +107,7 @@ const Accounts: React.FC = () => {
         justify="space-between"
         align="center"
         gap={8}
-        style={{ marginBottom: 16, marginTop: 4 }}
+        style={{ marginBottom: 8, marginTop: 4 }}
       >
         <Input.Search
           placeholder="Search by name or address"
@@ -110,11 +120,22 @@ const Accounts: React.FC = () => {
         <Button
           type="primary"
           onClick={() => authenticationRef.current?.open()}
-          loading={loadingCreateAccount}
-          disabled={loadingCreateAccount || loadingLoadAccounts}
+          loading={isCreating}
+          disabled={isCreating || loadingLoadAccounts}
         >
           Gen New Account
         </Button>
+      </Flex>
+      <Flex justify="flex-end" style={{ marginBottom: 16 }}>
+        <Segmented
+          value={selectedScheme}
+          onChange={(v) => setSelectedScheme(v as SigScheme)}
+          options={[
+            { label: "SPHINCS+", value: "sphincs+" },
+            { label: "ML-DSA-65", value: "mldsa65" },
+          ]}
+          size="small"
+        />
       </Flex>
       <div className={styles.accountListContainer}>
         <Spin size="large" spinning={loadingLoadAccounts}>

--- a/src/ui/store/models/interface.ts
+++ b/src/ui/store/models/interface.ts
@@ -1,7 +1,13 @@
+/** Signature scheme used by an account. Absent / undefined means "sphincs+" for backward compatibility. */
+export type SigScheme = "sphincs+" | "mldsa65";
+
 interface IAccount {
   name: string;
   address: string | null;
+  /** Hex-encoded lock script args. 64 hex chars (32 B) for SPHINCS+; 72 hex chars (36 B) for ML-DSA-65. */
   spxLockArgs: string;
+  /** Which post-quantum signature scheme this account uses. Defaults to "sphincs+" when absent. */
+  sigScheme?: SigScheme;
 }
 
 interface CurrentAccount extends IAccount {

--- a/src/ui/store/models/wallet.ts
+++ b/src/ui/store/models/wallet.ts
@@ -207,14 +207,23 @@ export const wallet = createModel<RootModel>()({
       }
     },
     async createWallet({ password }) {
-      // each function call to key-vault clears the password bytes buffer,
-      // here it is firstly used to generate the main wallet seed the to generate the first default account
-      // so clone password for the second call
       let clonedPassword: Uint8Array = new Uint8Array(0);
       try {
         clonedPassword = password.slice();
         await quantum.generateMasterSeed(password);
         await quantum.genAccount(clonedPassword);
+        this.loadCurrentAccount({});
+      } finally {
+        password.fill(0);
+        clonedPassword.fill(0);
+      }
+    },
+    async createWalletMlDsa({ password }) {
+      let clonedPassword: Uint8Array = new Uint8Array(0);
+      try {
+        clonedPassword = password.slice();
+        await quantum.generateMasterSeed(password);
+        await quantum.genMlDsa65Account(clonedPassword);
         this.loadCurrentAccount({});
       } finally {
         password.fill(0);

--- a/src/ui/store/models/wallet.ts
+++ b/src/ui/store/models/wallet.ts
@@ -90,12 +90,24 @@ export const wallet = createModel<RootModel>()({
     async loadAccounts() {
       if (!quantum) return;
       try {
-        const accounts = await quantum.getAllLockScriptArgs();
-        const accountsData = accounts.map((account, index) => ({
-          name: `Account ${index + 1}`,
-          spxLockArgs: account,
-          address: quantum.getAddress(account as Hex),
+        const spxAccounts = await quantum.getAllLockScriptArgs();
+        const mlDsaAccounts = await quantum.getAllMlDsaLockArgs();
+
+        const spxData = spxAccounts.map((lockArgs, index) => ({
+          name: `SPHINCS+ Account ${index + 1}`,
+          spxLockArgs: lockArgs,
+          address: quantum.getAddress(lockArgs as Hex, "sphincs+"),
+          scheme: "sphincs+" as const,
         }));
+
+        const mlDsaData = mlDsaAccounts.map((lockArgs, index) => ({
+          name: `ML-DSA-65 Account ${index + 1}`,
+          spxLockArgs: lockArgs,
+          address: quantum.getAddress(lockArgs as Hex, "mldsa65"),
+          scheme: "mldsa65" as const,
+        }));
+
+        const accountsData = [...spxData, ...mlDsaData];
         this.setAccounts(accountsData);
         return accountsData;
       } catch (error) {

--- a/src/ui/store/models/wallet.ts
+++ b/src/ui/store/models/wallet.ts
@@ -178,12 +178,16 @@ export const wallet = createModel<RootModel>()({
     async createAccount(payload: { password: Uint8Array }, rootState) {
       try {
         await quantum.genAccount(payload.password);
-
-        // Load accounts after creating a new account
         const accountsData: any = await this.loadAccounts();
-
-        // The new account is the last account in the accountsData array
-        // Return it to the caller to explorer the new account
+        return accountsData?.at(-1);
+      } finally {
+        payload.password.fill(0);
+      }
+    },
+    async createMlDsaAccount(payload: { password: Uint8Array }, rootState) {
+      try {
+        await quantum.genMlDsa65Account(payload.password);
+        const accountsData: any = await this.loadAccounts();
         return accountsData?.at(-1);
       } finally {
         payload.password.fill(0);

--- a/src/ui/store/models/wallet.ts
+++ b/src/ui/store/models/wallet.ts
@@ -316,6 +316,52 @@ export const wallet = createModel<RootModel>()({
         throw error;
       }
     },
+    async importWalletMlDsa({ srp, password }) {
+      let clonedPassword: Uint8Array = new Uint8Array(password.length);
+      let inloopClonePassword: Uint8Array = new Uint8Array(password.length);
+
+      try {
+        clonedPassword = password.slice();
+        await quantum.importSeedPhrase(srp, password);
+
+        let consecutiveEmpty = 0;
+        let accountIndex = 0;
+        let lastAccountWithBalance = -1;
+        const batchSize = FIND_ACCOUNT_THRESHOLD;
+
+        while (consecutiveEmpty < batchSize) {
+          inloopClonePassword = clonedPassword.slice();
+          const accounts = await quantum.genMlDsa65AccountInBatch(
+            inloopClonePassword,
+            accountIndex,
+            batchSize
+          );
+
+          for (let i = 0; i < accounts.length; i++) {
+            const lockArgs = accounts[i];
+            const balance = await quantum.getMlDsaBalance(lockArgs as Hex);
+
+            if (balance > BigInt(0)) {
+              lastAccountWithBalance = accountIndex + i;
+              consecutiveEmpty = 0;
+            } else {
+              consecutiveEmpty++;
+              if (consecutiveEmpty >= batchSize) break;
+            }
+          }
+          accountIndex += batchSize;
+        }
+
+        const accountsToRecover = lastAccountWithBalance >= 0 ? lastAccountWithBalance + 1 : 1;
+        await quantum.recoverMlDsaAccounts(clonedPassword, accountsToRecover);
+        this.setActive(true);
+      } finally {
+        srp.fill(0);
+        password.fill(0);
+        clonedPassword.fill(0);
+        inloopClonePassword.fill(0);
+      }
+    },
     async importWallet({ srp, password }) {
       // each function call to key-vault clears the password bytes buffer,
       // so clone password for the sequential calls

--- a/src/ui/store/models/wallet.ts
+++ b/src/ui/store/models/wallet.ts
@@ -9,6 +9,7 @@ interface IAccount {
   name: string;
   address: string | null;
   spxLockArgs: string;
+  scheme?: "sphincs+" | "mldsa65";
   balance?: string;
   lockedInDao?: string;
 }
@@ -234,9 +235,9 @@ export const wallet = createModel<RootModel>()({
         // throw error;
       }
     },
-    async switchAccount({ spxLockArgs }, rootState) {
+    async switchAccount({ spxLockArgs, scheme }, rootState) {
       try {
-        await quantum.setAccountPointer(spxLockArgs);
+        await quantum.setAccountPointer(spxLockArgs, scheme);
         this.loadCurrentAccount({});
         await DB.setItem(STORAGE_KEYS.CURRENT_ACCOUNT_POINTER, spxLockArgs);
       } catch (error) {


### PR DESCRIPTION
## Summary

Adds ML-DSA-65 (FIPS 204) as a second post-quantum signature scheme alongside the existing SPHINCS+, with full backward compatibility.

- **No breaking changes** — all existing SPHINCS+ accounts and addresses work unchanged
- **Same seed phrase** — ML-DSA-65 accounts derive from the same encrypted master seed via a distinct HKDF path (`ckb/quantum-purse/ml-dsa-65/{index}`), so no new backup is needed
- **BIP-39 compatible** — only the 32-byte HKDF seed `ξ` needs backup; the 4032-byte SK is always re-derived on demand, never stored
- **Schema v2** — additive IndexedDB migration adds `ml_dsa_keys_store` alongside existing stores

## Changes

### `src/core/config.ts`
- Adds `MLDSA_LOCK` export with testnet `type_id` (`0x8984f4...`) from the [`ckb-mldsa-lock`](https://github.com/toastmanAu/ckb-mldsa-lock) contract and a mainnet placeholder

### `src/ui/store/models/interface.ts`
- Adds `SigScheme = "sphincs+" | "mldsa65"` type
- Extends `IAccount` with optional `sigScheme` field (absent = `"sphincs+"` for backward compat)
- Documents that `spxLockArgs` is 64 hex chars for SPHINCS+ and 72 hex chars for ML-DSA-65

### `src/core/ccc-adapter/qp_signer.ts`
- Adds `sigScheme` field and `activeLock` getter that switches between `MLDSA_LOCK` and `spxLock`
- `setAccountPointer()` now accepts an optional `scheme` parameter and validates against the correct DB store
- `prepareTransaction()` uses `MLDSA65_WITNESS_LOCK_SIZE = 5305` for ML-DSA accounts
- `signOnlyTransaction()` routes to the correct signing path:
  - ML-DSA-65: passes raw `tx.hash()` bytes to WASM; the lock script domain-hashes internally (`blake2b("CKB-MLDSA-LOCK" || tx_hash)`)
  - SPHINCS+: unchanged — uses `tx_message_all` hash (RFC-0000)

### `src/core/quantum_purse.ts`
- Adds `genMlDsa65Account(password)` — derives new ML-DSA-65 account, registers with light client, returns `{ lockArgs, address }`
- Adds `getAllMlDsaLockArgs()` and scheme-aware `getAddress()` helpers

## Depends On

Requires the WASM key vault from [`QuantumPurse/key-vault-wasm#11`](https://github.com/QuantumPurse/key-vault-wasm/pull/11) which adds:
- New `ckb-fips204-utils` crate (ML-DSA-65 keygen/signing, HKDF derivation, Molecule witness serialization)
- DB schema v2 with `ml_dsa_keys_store`
- Five new `#[wasm_bindgen]` methods on `KeyVault`

## Test Plan

- [ ] `wasm-pack build` succeeds in key-vault-wasm with the new crate
- [ ] SPHINCS+ account flow unchanged (create, sign, verify address)
- [ ] ML-DSA-65 account creation generates 72-char lock args
- [ ] ML-DSA-65 signing produces a valid 5305-byte `MldsaWitness` placed in `WitnessArgs.lock`
- [ ] Transaction accepted by testnet node (lock script cycle budget: 4,761,583 / 70,000,000)
- [ ] Existing SPHINCS+ accounts survive the schema v1 → v2 migration with no data loss
- [ ] Same mnemonic recovers both SPHINCS+ and ML-DSA-65 accounts