### PR TITLE
feat: add ML-DSA-65 (FIPS 204) as a complete alternative signature scheme

### DIFF
--- a/docs/mldsa65-testing.md
+++ b/docs/mldsa65-testing.md
@@ -1,0 +1,160 @@
+# ML-DSA-65 Testing Guide
+
+This document covers how to build and test the ML-DSA-65 (FIPS 204) feature branch
+(`feat/mldsa65`) before it is published to npm. The WASM binary is already compiled
+into the bundle, so no Rust toolchain is required for basic testing.
+
+---
+
+## Quick Test — Deploy Pre-Built Bundle to Vercel
+
+The `public/` folder contains a production webpack build with the ML-DSA-65 WASM
+already compiled in. You can deploy it as a static site in under a minute:
+
+```bash
+# Install Vercel CLI if needed
+npm i -g vercel
+
+# Clone this branch
+git clone -b feat/mldsa65 https://github.com/toastmanAu/quantum-purse.git
+cd quantum-purse
+
+# Deploy the pre-built output — no rebuild required
+vercel deploy public/ --name quantum-purse-mldsa-test
+```
+
+Vercel will give you a preview URL (e.g. `https://quantum-purse-mldsa-test-xxx.vercel.app`).
+Open it in **Chrome, Brave, or Safari** — the light client requires SharedArrayBuffer,
+which needs the COOP/COEP headers already set in `vercel.json`.
+
+---
+
+## What to Test
+
+### 1. Wallet Setup
+
+- [ ] Create a new wallet with a password
+- [ ] Record the seed phrase shown during setup
+- [ ] Confirm the wallet loads to the main screen
+
+### 2. Create an ML-DSA-65 Account
+
+- [ ] Navigate to **Accounts → New Account**
+- [ ] Select **ML-DSA-65** as the signature scheme
+- [ ] Confirm an address beginning with `ckt` (testnet) is generated
+- [ ] Confirm the address is distinct from any SPHINCS+ address on the same wallet
+
+### 3. SPHINCS+ Coexistence
+
+- [ ] Create a second account using **SPHINCS+**
+- [ ] Confirm both accounts appear in the account list
+- [ ] Confirm each shows its correct scheme label
+- [ ] Switch between accounts and verify addresses update correctly
+
+### 4. Receive Funds (Testnet)
+
+- [ ] Copy the ML-DSA-65 account address
+- [ ] Request testnet CKB from the [Nervos faucet](https://faucet.nervos.org/)
+  - Minimum 73 CKB required (quantum-resistant lock scripts need more capacity)
+- [ ] Wait for the light client to sync (peer count and sync % shown in header)
+- [ ] Confirm the balance appears on the ML-DSA-65 account
+
+### 5. Send a Transaction
+
+- [ ] Navigate to **Send** with the ML-DSA-65 account selected
+- [ ] Enter a testnet destination address and an amount (≥ 73 CKB recommended)
+- [ ] Enter your wallet password when prompted
+- [ ] Confirm the transaction is broadcast and appears in the CKB testnet explorer
+  - Explorer: https://testnet.explorer.nervos.org/
+
+### 6. Wallet Recovery
+
+- [ ] Delete the wallet (clear IndexedDB via browser DevTools → Application → Storage)
+- [ ] Restore from the seed phrase recorded in step 1
+- [ ] Confirm ML-DSA-65 accounts are recovered via **Recover Accounts**
+  > **Note:** Light client sync speed affects batch recovery. If only the first
+  > account appears, create additional accounts manually and use the context menu
+  > to set the correct starting block from the explorer.
+
+### 7. Cross-Scheme Send
+
+- [ ] Send from a **SPHINCS+** account to the **ML-DSA-65** address
+- [ ] Confirm receipt on the ML-DSA-65 account
+- [ ] Send from **ML-DSA-65** back to the **SPHINCS+** address
+- [ ] Confirm both transactions appear correctly in explorer
+
+---
+
+## Build From Source (Optional)
+
+If you want to verify the full build rather than using the pre-built bundle:
+
+### Prerequisites
+
+```bash
+# Rust + wasm toolchain
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup target add wasm32-unknown-unknown
+curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+# Node
+node >= 18, npm >= 9
+```
+
+### Build
+
+```bash
+# 1. Build the WASM key vault
+git clone -b feat/mldsa65 https://github.com/toastmanAu/key-vault-wasm.git
+cd key-vault-wasm
+bash build.sh
+cd ..
+
+# 2. Build the web app pointing at the local WASM
+git clone -b feat/mldsa65 https://github.com/toastmanAu/quantum-purse.git
+cd quantum-purse
+npm install ../key-vault-wasm/dist
+npm run build:web
+
+# 3. Deploy or serve locally
+vercel deploy public/ --name quantum-purse-mldsa-test
+# or: npx serve public/
+```
+
+---
+
+## Known Limitations (This Branch)
+
+| Limitation | Details |
+|------------|---------|
+| Mainnet lock script | ML-DSA-65 lock is testnet-only (`ckb-mldsa-lock`). Mainnet deployment pending review. |
+| `key-vault-wasm` not on npm | Using local path dep. Will be published after review. |
+| Deterministic signing | Uses `try_sign_with_seed([0u8;32])` — the hedging seed is fixed zeros. Acceptable for CKB (deterministic signing is standard practice); can be upgraded to OS randomness post-review. |
+| Batch account recovery | Same light-client sync limitation as SPHINCS+ — only first account auto-recovers on slow sync. |
+
+---
+
+## Key Changes in This Branch
+
+### `key-vault-wasm` (`feat/mldsa65`)
+
+- New crate: `crates/ckb-fips204-utils` — ML-DSA-65 key derivation and signing
+- `src/lib.rs` — `gen_new_ml_dsa_account`, `sign_ml_dsa`, `recover_ml_dsa_accounts`, `get_all_ml_dsa_lock_args`
+- `src/db.rs` — `MlDsaAccount` record type, IndexedDB store `ml-dsa-accounts`
+- Same master seed covers both SPHINCS+ and ML-DSA-65 via separate HKDF paths — **no new backup needed**
+
+### `quantum-purse` (`feat/mldsa65`)
+
+- `src/core/config.ts` — `MLDSA_LOCK` config, `SigScheme` type
+- `src/core/quantum_purse.ts` — `genNewMlDsaAccount`, `recoverMlDsaAccounts`, scheme-aware `getAddress`
+- `src/core/ccc-adapter/qp_signer.ts` — `QpMlDsaSigner` extending `CCC Signer`
+- `src/ui/` — account type selector, ML-DSA badge, scheme-aware send flow
+
+---
+
+## Reporting Issues
+
+Please comment on the PR with:
+- Browser and OS
+- Which test step failed
+- Any console errors (F12 → Console)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@rematch/loading": "2.1.2",
         "antd": "6.3.5",
         "qrcode.react": "4.2.0",
-        "quantum-purse-key-vault": "0.3.1",
+        "quantum-purse-key-vault": "file:../key-vault-wasm/dist",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-redux": "9.2.0",
@@ -63,6 +63,11 @@
         "webpack-dev-server": "5.2.3",
         "webpack-merge": "6.0.1"
       }
+    },
+    "../key-vault-wasm/dist": {
+      "name": "quantum-purse-key-vault",
+      "version": "0.4.0",
+      "license": "MIT"
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
@@ -2932,6 +2937,27 @@
         "@parcel/watcher-win32-x64": "2.5.1"
       }
     },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/watcher-darwin-arm64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
@@ -2944,6 +2970,255 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10.0.0"
@@ -4003,6 +4278,23 @@
       "peerDependencies": {
         "@rematch/core": ">=2"
       }
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.5.tgz",
+      "integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -8440,6 +8732,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -10186,7 +10488,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -13369,10 +13671,8 @@
       }
     },
     "node_modules/quantum-purse-key-vault": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/quantum-purse-key-vault/-/quantum-purse-key-vault-0.3.1.tgz",
-      "integrity": "sha512-nsXSFZaDjn33ToMZwKCmiHR2JoQLPTn15BfUEIIfaa916my+trHOkCvR6iHs3uIQrCLHmEH4MDF8t6vLoxNFMg==",
-      "license": "MIT"
+      "resolved": "../key-vault-wasm/dist",
+      "link": true
     },
     "node_modules/querystring-es3": {
       "version": "0.2.1",
@@ -14128,7 +14428,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@rematch/loading": "2.1.2",
     "antd": "6.3.5",
     "qrcode.react": "4.2.0",
-    "quantum-purse-key-vault": "0.3.1",
+    "quantum-purse-key-vault": "file:../key-vault-wasm/dist",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-redux": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@rematch/loading": "2.1.2",
     "antd": "6.3.5",
     "qrcode.react": "4.2.0",
-    "quantum-purse-key-vault": "file:../key-vault-wasm/dist",
+    "quantum-purse-key-vault": "file:./vendor-key-vault",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-redux": "9.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,10 @@ import InactiveLayout from "./ui/layouts/InactiveLayout";
 import {
   CommingSoon,
   CreateWallet,
+  CreateWalletMlDsa,
   EjectWallet,
   ImportWallet,
+  ImportWalletMlDsa,
   Receive,
   RevealSRP,
   Send,
@@ -130,6 +132,8 @@ const App: React.FC = () => {
           <Route path={ROUTES.WELCOME} element={<Welcome />} />
           <Route path={ROUTES.CREATE_WALLET} element={<CreateWallet />} />
           <Route path={ROUTES.IMPORT_WALLET} element={<ImportWallet />} />
+          <Route path={ROUTES.CREATE_WALLET_MLDSA} element={<CreateWalletMlDsa />} />
+          <Route path={ROUTES.IMPORT_WALLET_MLDSA} element={<ImportWalletMlDsa />} />
         </Route>
         <Route path={ROUTES.HOME} element={<ActiveLayout />}>
           <Route path={ROUTES.RECEIVE} element={<Receive />} />

--- a/src/core/ccc-adapter/qp_signer.ts
+++ b/src/core/ccc-adapter/qp_signer.ts
@@ -1,5 +1,5 @@
 // qp_signer.ts
-// A sphincs+_based CCC compatible signer
+// A post-quantum CCC compatible signer supporting SPHINCS+ and ML-DSA-65.
 
 import {
   Signer,
@@ -12,24 +12,31 @@ import {
   BytesLike,
   Script,
   hexFrom,
+  bytesFrom,
   WitnessArgs,
   HashTypeLike
 } from "@ckb-ccc/core";
 import { QPClient } from "./qp_client";
-import { IS_MAIN_NET } from "../config";
+import { IS_MAIN_NET, MLDSA_LOCK } from "../config";
 import __wbg_init, { KeyVault, SpxVariant } from "quantum-purse-key-vault";
 import { get_ckb_tx_message_all_hash } from "../utils";
+import type { SigScheme } from "../../ui/store/models/interface";
+
+/** Size of the MldsaWitness Molecule table placed in WitnessArgs.lock (bytes). */
+const MLDSA65_WITNESS_LOCK_SIZE = 5305;
 
 export class QPSigner extends Signer {
   public accountPointer?: BytesLike;
-  protected spxLock: { codeHash: BytesLike, hashType: HashTypeLike };
+  /** Signature scheme of the currently active account. */
+  public sigScheme: SigScheme = "sphincs+";
+  protected spxLock: { codeHash: BytesLike; hashType: HashTypeLike };
   protected keyVault?: KeyVault;
   public requestPassword?: (
     resolve: (password: Uint8Array) => void,
     reject: () => void
   ) => void;
 
-  constructor(spxLockInfo: { codeHash: BytesLike, hashType: HashTypeLike }) {
+  constructor(spxLockInfo: { codeHash: BytesLike; hashType: HashTypeLike }) {
     super(new QPClient());
     this.spxLock = spxLockInfo;
   }
@@ -38,24 +45,44 @@ export class QPSigner extends Signer {
     return this.client_ as QPClient;
   }
 
-  async setAccountPointer(accPointer: BytesLike) {
-    const lockArgsList = await this.getAllLockScriptArgs();
-    if (!lockArgsList.includes(accPointer as string)) throw Error("Invalid account pointer");
+  /**
+   * Set the active account pointer, validating it exists in the DB.
+   * Also sets `sigScheme` based on which store the lock args belong to.
+   */
+  async setAccountPointer(accPointer: BytesLike, scheme?: SigScheme) {
+    if (scheme === "mldsa65") {
+      const mldsaList = await KeyVault.get_all_ml_dsa_lock_args();
+      if (!mldsaList.includes(accPointer as string))
+        throw Error("Invalid ML-DSA-65 account pointer");
+      this.sigScheme = "mldsa65";
+    } else {
+      const spxList = await this.getAllLockScriptArgs();
+      if (!spxList.includes(accPointer as string))
+        throw Error("Invalid SPHINCS+ account pointer");
+      this.sigScheme = "sphincs+";
+    }
     this.accountPointer = accPointer;
   }
 
   /**
-   * Retrieve all sphincs+ lock script arguments from all child accounts in the indexed DB.
-   * @returns An ordered array of all child key's sphincs+ lock script argument.
+   * Retrieve all SPHINCS+ lock script arguments from the indexed DB.
+   * @returns An ordered array of all SPHINCS+ lock script args.
    */
   public async getAllLockScriptArgs(): Promise<string[]> {
     return await KeyVault.get_all_sphincs_lock_args();
   }
 
   /**
-   * Initialize the key-vault instance from within Signer with a pre-determined SPHINCS variant.
+   * Retrieve all ML-DSA-65 lock script arguments from the indexed DB.
+   * @returns An ordered array of all ML-DSA-65 lock script args.
+   */
+  public async getAllMlDsaLockArgs(): Promise<string[]> {
+    return await KeyVault.get_all_ml_dsa_lock_args();
+  }
+
+  /**
+   * Initialize the key-vault instance with a pre-determined SPHINCS+ variant.
    * @param variant The SPHINCS+ parameter set to start with
-   * @returns void.
    */
   protected initKeyVaultCore(variant: SpxVariant) {
     if (this.keyVault) {
@@ -64,9 +91,16 @@ export class QPSigner extends Signer {
     this.keyVault = new KeyVault(variant);
   }
 
-  /* Wasm-bindgen module init code for Key Vault */
+  /** Wasm-bindgen module init code for Key Vault */
   protected async initKeyVaultWBG(): Promise<void> {
     await __wbg_init();
+  }
+
+  /** Returns the active lock script config based on the current sig scheme. */
+  protected get activeLock(): { codeHash: BytesLike; hashType: HashTypeLike } {
+    return this.sigScheme === "mldsa65"
+      ? { codeHash: MLDSA_LOCK.codeHash, hashType: MLDSA_LOCK.hashType }
+      : this.spxLock;
   }
 
   /** CKB network */
@@ -74,87 +108,96 @@ export class QPSigner extends Signer {
     return SignerType.CKB;
   }
 
-  /** Signature type is SPHINCS+ */
+  /** Signature type is post-quantum (SPHINCS+ or ML-DSA-65) */
   get signType(): SignerSignType {
     return SignerSignType.Unknown;
   }
 
-  /** Connect (no-op since private key must be authenticated via password each use) */
+  /** Connect (no-op — private key is authenticated per signing call) */
   async connect(): Promise<void> {
     return;
   }
 
   /** Check connection status */
   async isConnected(): Promise<boolean> {
-    return false; // never connected
+    return false;
   }
 
-  /** Get internal address */
+  /** Get internal address using the active lock script */
   async getInternalAddress(): Promise<string> {
     const lock = Script.from({
-      codeHash: this.spxLock.codeHash,
-      hashType: this.spxLock.hashType,
-      args: this.accountPointer as string
+      codeHash: this.activeLock.codeHash,
+      hashType: this.activeLock.hashType,
+      args: this.accountPointer as string,
     });
     return Address.fromScript(lock, this.client).toString();
   }
 
-  /** Get address objects 
-   * Due to the current design of Quantum Purse, this function will only return 
-   * the address object matching this.accountPointer, not all the address objects.
+  /**
+   * Get address objects for the active account.
+   * Returns only the address for the current accountPointer.
    */
   async getAddressObjs(): Promise<Address[]> {
     return [
       {
         script: Script.from({
-          codeHash: this.spxLock.codeHash,
-          hashType: this.spxLock.hashType,
-          args: this.accountPointer as string
+          codeHash: this.activeLock.codeHash,
+          hashType: this.activeLock.hashType,
+          args: this.accountPointer as string,
         }),
-        prefix: IS_MAIN_NET ? "ckb" : "ckt"
-      }
+        prefix: IS_MAIN_NET ? "ckb" : "ckt",
+      },
     ];
   }
 
-  /** Verify message */
-  async verifyMessage(message: string | BytesLike, signature: string | Signature): Promise<boolean> {
+  /** Verify message — not supported for post-quantum signers */
+  async verifyMessage(
+    _message: string | BytesLike,
+    _signature: string | Signature
+  ): Promise<boolean> {
     throw new Error("Unsupported method: verifyMessage");
   }
 
-  /** Prepare transaction */
+  /** Prepare transaction — reserves the correct witness placeholder size */
   async prepareTransaction(txLike: TransactionLike): Promise<Transaction> {
     if (!this.keyVault) throw new Error("KeyVault not initialized!");
 
     const tx = Transaction.from(txLike);
     const { script } = await this.getRecommendedAddressObj();
-    const witnessLockSizeMap = {
-      [SpxVariant.Sha2128F]: 17125,
-      [SpxVariant.Shake128F]: 17125,
-      [SpxVariant.Sha2128S]: 7893,
-      [SpxVariant.Shake128S]: 7893,
-      [SpxVariant.Sha2192F]: 35717,
-      [SpxVariant.Shake192F]: 35717,
-      [SpxVariant.Sha2192S]: 16277,
-      [SpxVariant.Shake192S]: 16277,
-      [SpxVariant.Sha2256F]: 49925,
-      [SpxVariant.Shake256F]: 49925,
-      [SpxVariant.Sha2256S]: 29861,
-      [SpxVariant.Shake256S]: 29861,
-    };
-    const variant = this.keyVault.variant;
-    const witnessLockSize = witnessLockSizeMap[variant] || 0;
+
+    let witnessLockSize: number;
+
+    if (this.sigScheme === "mldsa65") {
+      witnessLockSize = MLDSA65_WITNESS_LOCK_SIZE;
+    } else {
+      const spxSizeMap: Record<SpxVariant, number> = {
+        [SpxVariant.Sha2128F]: 17125,
+        [SpxVariant.Shake128F]: 17125,
+        [SpxVariant.Sha2128S]: 7893,
+        [SpxVariant.Shake128S]: 7893,
+        [SpxVariant.Sha2192F]: 35717,
+        [SpxVariant.Shake192F]: 35717,
+        [SpxVariant.Sha2192S]: 16277,
+        [SpxVariant.Shake192S]: 16277,
+        [SpxVariant.Sha2256F]: 49925,
+        [SpxVariant.Shake256F]: 49925,
+        [SpxVariant.Sha2256S]: 29861,
+        [SpxVariant.Shake256S]: 29861,
+      };
+      witnessLockSize = spxSizeMap[this.keyVault.variant] ?? 0;
+    }
+
     await tx.prepareSighashAllWitness(script, witnessLockSize, this.client);
     return tx;
   }
 
-  /** Sign only the transaction */
+  /** Sign only the transaction, routing to the correct scheme */
   async signOnlyTransaction(txLike: TransactionLike): Promise<Transaction> {
     let password: Uint8Array = new Uint8Array(0);
     try {
       if (!this.keyVault) throw new Error("KeyVault not initialized!");
 
       const tx = Transaction.from(txLike);
-      const message = get_ckb_tx_message_all_hash(tx); // TODO: Update when new CCC core support is released
 
       const passwordHandler = new Promise<Uint8Array>((resolve, reject) => {
         if (this.requestPassword) {
@@ -165,10 +208,30 @@ export class QPSigner extends Signer {
       });
 
       password = await passwordHandler;
-      const spxSig = await this.keyVault.sign(password, this.accountPointer as string, message);
       const position = 0;
       const witness = tx.getWitnessArgsAt(position) ?? WitnessArgs.from({});
-      witness.lock = hexFrom(spxSig);
+
+      if (this.sigScheme === "mldsa65") {
+        // ML-DSA-65: our lock script verifies blake2b("CKB-MLDSA-LOCK" || tx_hash).
+        // Pass the raw tx_hash to WASM; it constructs the signing message internally.
+        const txHashBytes = new Uint8Array(bytesFrom(tx.hash()));
+        const mldsaWitness = await this.keyVault.sign_ml_dsa(
+          password,
+          this.accountPointer as string,
+          txHashBytes
+        );
+        witness.lock = hexFrom(mldsaWitness);
+      } else {
+        // SPHINCS+: use the full CKB tx_message_all hash (RFC-0000)
+        const message = get_ckb_tx_message_all_hash(tx);
+        const spxSig = await this.keyVault.sign(
+          password,
+          this.accountPointer as string,
+          message
+        );
+        witness.lock = hexFrom(spxSig);
+      }
+
       tx.setWitnessArgsAt(position, witness);
       return tx;
     } catch (error: any) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -25,6 +25,34 @@ export const SPHINCSPLUS_LOCK = IS_MAIN_NET
     depType: "code",
   };
 
+// ML-DSA-65 (FIPS 204) Lock Script contract
+// Testnet type_id: deployed via ckb-mldsa-lock (github.com/toastmanAu/ckb-mldsa-lock)
+// Mainnet: not yet deployed — use testnet config as placeholder until mainnet launch.
+export const MLDSA_LOCK = IS_MAIN_NET
+  ? {
+    // TODO: replace with mainnet deployment once audited and deployed
+    codeHash:
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+    hashType: "type" as const,
+    outPoint: {
+      txHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      index: "0x0",
+    },
+    depType: "code" as const,
+  } : {
+    // type_id — stable across contract upgrades
+    codeHash:
+      "0x8984f4230ded4ac1f5efee2b67fef45fcda08bd6344c133a2f378e2f469d310d",
+    hashType: "type" as const,
+    outPoint: {
+      txHash:
+        "0xba4a6560ef719b24d170bf678611b25b799c56e6a80f18ce9c79e9561085cba7",
+      index: "0x0",
+    },
+    depType: "code" as const,
+  };
+
 // Nervos DAO Type Script contract
 export const NERVOS_DAO = IS_MAIN_NET
   ? {

--- a/src/core/quantum_purse.ts
+++ b/src/core/quantum_purse.ts
@@ -231,6 +231,7 @@ export default class QuantumPurse extends QPSigner {
       return;
     }
     await this.client.fetchTransaction(SPHINCSPLUS_LOCK.outPoint.txHash);
+    await this.client.fetchTransaction(MLDSA_LOCK.outPoint.txHash);
   }
 
   /**

--- a/src/core/quantum_purse.ts
+++ b/src/core/quantum_purse.ts
@@ -121,14 +121,17 @@ export default class QuantumPurse extends QPSigner {
   */
   private async setSellectiveSyncFilterInternal(
     spxLockArgs: Hex,
-    firstAccount: boolean
+    firstAccount: boolean,
+    scheme: SigScheme = "sphincs+"
   ): Promise<void> {
     if (!this.hasClientStarted) {
       logger("error", "Light client has not initialized");
       return Promise.resolve();
     }
 
-    const lock = this.getLockScript(spxLockArgs);
+    const lock = scheme === "mldsa65"
+      ? { codeHash: MLDSA_LOCK.codeHash, hashType: MLDSA_LOCK.hashType, args: spxLockArgs }
+      : this.getLockScript(spxLockArgs);
     const storageKey = QuantumPurse.START_BLOCK_PREFIX + "_" + spxLockArgs.slice(0, 16);
     let startingBlock: bigint = (await this.client!.getTipHeader()).number;
 
@@ -440,7 +443,7 @@ export default class QuantumPurse extends QPSigner {
 
       // Register the new lock script with the light client for balance tracking
       const existingCount = (await this.getAllMlDsaLockArgs()).length;
-      await this.setSellectiveSyncFilterInternal(lockArgs as Hex, existingCount <= 1);
+      await this.setSellectiveSyncFilterInternal(lockArgs as Hex, existingCount <= 1, "mldsa65");
 
       return { lockArgs, address };
     } finally {

--- a/src/core/quantum_purse.ts
+++ b/src/core/quantum_purse.ts
@@ -322,16 +322,6 @@ export default class QuantumPurse extends QPSigner {
     };
   }
 
-  /**
-   * Gets the blockchain address.
-   * @param spxLockArgs - The sphincs+ lock script arguments.
-   * @returns The CKB address as a string.
-   * @throws Error if no account pointer is set by default (see `getLockScript` for details).
-   */
-  public getAddress(spxLockArgs?: BytesLike): string {
-    const lock = this.getLockScript(spxLockArgs);
-    return Address.fromScript(lock, this.client).toString();
-  }
 
   /**
    * Gets account available (transferable) balance via light client protocol.

--- a/src/core/quantum_purse.ts
+++ b/src/core/quantum_purse.ts
@@ -724,12 +724,13 @@ export default class QuantumPurse extends QPSigner {
       throw(Error("Minimal transfer amount is " + ccc.fixedPointToString(tx.outputs[0].capacity)));
     }
     tx.outputs[0].capacity = ccc.fixedPointFrom(amount);
-    
+
     // cell deps
+    const lockInfo = this.sigScheme === "mldsa65" ? MLDSA_LOCK : SPHINCSPLUS_LOCK;
     tx.addCellDeps([
       {
-        outPoint: SPHINCSPLUS_LOCK.outPoint,
-        depType: SPHINCSPLUS_LOCK.depType as DepType,
+        outPoint: lockInfo.outPoint,
+        depType: lockInfo.depType as DepType,
       }
     ]);
 
@@ -768,10 +769,11 @@ export default class QuantumPurse extends QPSigner {
     );
     
     // cell deps
+    const lockInfo = this.sigScheme === "mldsa65" ? MLDSA_LOCK : SPHINCSPLUS_LOCK;
     tx.addCellDeps([
       {
-        outPoint: SPHINCSPLUS_LOCK.outPoint,
-        depType: SPHINCSPLUS_LOCK.depType as DepType,
+        outPoint: lockInfo.outPoint,
+        depType: lockInfo.depType as DepType,
       }
     ]);
 
@@ -823,10 +825,11 @@ export default class QuantumPurse extends QPSigner {
     tx.outputs[0].capacity = ccc.fixedPointFrom(amount);
 
     // cell deps
+    const lockInfo = this.sigScheme === "mldsa65" ? MLDSA_LOCK : SPHINCSPLUS_LOCK;
     tx.addCellDeps([
       {
-        outPoint: SPHINCSPLUS_LOCK.outPoint,
-        depType: SPHINCSPLUS_LOCK.depType as DepType,
+        outPoint: lockInfo.outPoint,
+        depType: lockInfo.depType as DepType,
       },
       {
         outPoint: NERVOS_DAO.outPoint,
@@ -875,17 +878,18 @@ export default class QuantumPurse extends QPSigner {
     });
 
     // cell deps
+    const lockInfo = this.sigScheme === "mldsa65" ? MLDSA_LOCK : SPHINCSPLUS_LOCK;
     tx.addCellDeps([
       {
-        outPoint: SPHINCSPLUS_LOCK.outPoint,
-        depType: SPHINCSPLUS_LOCK.depType as DepType,
+        outPoint: lockInfo.outPoint,
+        depType: lockInfo.depType as DepType,
       },
       {
         outPoint: NERVOS_DAO.outPoint,
         depType: NERVOS_DAO.depType as DepType,
       }
     ]);
-    
+
     await tx.completeInputsAll(this);
     await tx.completeFeeChangeToOutput(this, 0, feeRate);
     if (signOffline)
@@ -935,10 +939,11 @@ export default class QuantumPurse extends QPSigner {
     });
 
     // cell deps
+    const lockInfo = this.sigScheme === "mldsa65" ? MLDSA_LOCK : SPHINCSPLUS_LOCK;
     tx.addCellDeps([
       {
-        outPoint: SPHINCSPLUS_LOCK.outPoint,
-        depType: SPHINCSPLUS_LOCK.depType as DepType,
+        outPoint: lockInfo.outPoint,
+        depType: lockInfo.depType as DepType,
       },
       {
         outPoint: NERVOS_DAO.outPoint,
@@ -1008,10 +1013,11 @@ export default class QuantumPurse extends QPSigner {
     });
 
     // cell deps
+    const lockInfo = this.sigScheme === "mldsa65" ? MLDSA_LOCK : SPHINCSPLUS_LOCK;
     tx.addCellDeps([
       {
-        outPoint: SPHINCSPLUS_LOCK.outPoint,
-        depType: SPHINCSPLUS_LOCK.depType as DepType,
+        outPoint: lockInfo.outPoint,
+        depType: lockInfo.depType as DepType,
       },
       {
         outPoint: NERVOS_DAO.outPoint,

--- a/src/core/quantum_purse.ts
+++ b/src/core/quantum_purse.ts
@@ -1,5 +1,6 @@
 // QuantumPurse.ts
-import { IS_MAIN_NET, SPHINCSPLUS_LOCK, NERVOS_DAO } from "./config";
+import { IS_MAIN_NET, SPHINCSPLUS_LOCK, MLDSA_LOCK, NERVOS_DAO } from "./config";
+import type { IAccount, SigScheme } from "../ui/store/models/interface";
 import { KeyVault, Util as KeyVaultUtil, SpxVariant } from "quantum-purse-key-vault";
 import { randomSecretKey, LightClientSetScriptsCommand, ScriptStatus } from "@nervosnetwork/ckb-light-client-js";
 import testnetConfig from "../../light-client/network.test.toml";
@@ -419,6 +420,74 @@ export default class QuantumPurse extends QPSigner {
     } finally {
       password.fill(0);
     }
+  }
+
+  /**
+   * Generates a new ML-DSA-65 account derived from the wallet master seed.
+   *
+   * The keypair is never stored — only the 36-byte lock args are persisted in IndexedDB.
+   * On each signing call the secret key is re-derived from the master seed via HKDF.
+   *
+   * @param password - The wallet password (will be zeroed after use).
+   * @returns The lock args hex string and the CKB address for the new ML-DSA-65 account.
+   * @throws Error if the master seed is not found or decryption fails.
+   */
+  public async genMlDsa65Account(
+    password: Uint8Array
+  ): Promise<{ lockArgs: string; address: string }> {
+    try {
+      if (!this.keyVault) throw new Error("KeyVault not initialized!");
+
+      const lockArgs = await this.keyVault.gen_new_ml_dsa_account(password);
+
+      // Build the CKB address using the ML-DSA-65 lock script
+      const lock = {
+        codeHash: MLDSA_LOCK.codeHash,
+        hashType: MLDSA_LOCK.hashType,
+        args: lockArgs as Hex,
+      };
+      const address = this.getAddress(lockArgs as Hex, "mldsa65");
+
+      // Register the new lock script with the light client for balance tracking
+      const existingCount = (await this.getAllMlDsaLockArgs()).length;
+      await this.setSellectiveSyncFilterInternal(lockArgs as Hex, existingCount <= 1);
+
+      return { lockArgs, address };
+    } finally {
+      password.fill(0);
+    }
+  }
+
+  /**
+   * Returns the CKB address for a given lock args and signature scheme.
+   * @param lockArgs - The lock script args (hex string).
+   * @param scheme - The signature scheme ("sphincs+" or "mldsa65").
+   */
+  public getAddress(lockArgs?: BytesLike, scheme: SigScheme = "sphincs+"): string {
+    const lockInfo = scheme === "mldsa65" ? MLDSA_LOCK : SPHINCSPLUS_LOCK;
+    const lock = this.getLockScriptForScheme(lockArgs, lockInfo);
+    const addr = Address.fromScript(lock as any, this.client);
+    return addr.toString();
+  }
+
+  /**
+   * Retrieve all ML-DSA-65 lock script args stored in IndexedDB.
+   */
+  public async getAllMlDsaLockArgs(): Promise<string[]> {
+    return await KeyVault.get_all_ml_dsa_lock_args();
+  }
+
+  // ── internal helpers ──────────────────────────────────────────────────────
+
+  private getLockScriptForScheme(
+    lockArgs: BytesLike | undefined,
+    lockInfo: { codeHash: string; hashType: string }
+  ) {
+    return {
+      codeHash: lockInfo.codeHash,
+      hashType: lockInfo.hashType,
+      args: lockArgs !== undefined ? lockArgs : (this.accountPointer as string),
+    };
   }
 
   /**

--- a/src/core/quantum_purse.ts
+++ b/src/core/quantum_purse.ts
@@ -608,6 +608,87 @@ export default class QuantumPurse extends QPSigner {
   }
 
   /**
+   * Derives ML-DSA-65 lock args in a batch without persisting them — used for
+   * account discovery during wallet import.
+   */
+  public async genMlDsa65AccountInBatch(
+    password: Uint8Array,
+    startIndex: number,
+    count: number
+  ): Promise<string[]> {
+    try {
+      if (!this.keyVault) throw new Error("KeyVault not initialized!");
+      return await this.keyVault.try_gen_ml_dsa_account_batch(password, startIndex, count);
+    } finally {
+      password.fill(0);
+    }
+  }
+
+  /**
+   * Derives and persists `count` ML-DSA-65 accounts from index 0, registering
+   * each with the light client for balance tracking.
+   */
+  public async recoverMlDsaAccounts(password: Uint8Array, count: number): Promise<void> {
+    try {
+      if (!this.keyVault) throw new Error("KeyVault not initialized!");
+      const lockArgsList = await this.keyVault.recover_ml_dsa_accounts(password, count) as Hex[];
+
+      if (!this.hasClientStarted) {
+        logger("error", "Light client has not initialized");
+        return;
+      }
+
+      const startBlocksPromises = lockArgsList.map(async (lockArgs) => {
+        const lock = {
+          codeHash: MLDSA_LOCK.codeHash,
+          hashType: MLDSA_LOCK.hashType,
+          args: lockArgs as Hex,
+        };
+        const searchKey: ClientIndexerSearchKeyLike = {
+          scriptType: "lock",
+          script: lock,
+          scriptSearchMode: "prefix",
+        };
+
+        let startBlock = BigInt(0);
+        const response = await this.client.getTransactions(searchKey, "asc", 1);
+        if (response.transactions && response.transactions.length > 0) {
+          startBlock = response.transactions[0].blockNumber - BigInt(1);
+        }
+        return startBlock;
+      });
+
+      const startBlocks = await Promise.all(startBlocksPromises);
+      await this.setSellectiveSyncFilter(lockArgsList, startBlocks, LightClientSetScriptsCommand.All);
+    } finally {
+      password.fill(0);
+    }
+  }
+
+  /**
+   * Gets available balance for an ML-DSA-65 account via the light client.
+   */
+  public async getMlDsaBalance(lockArgs: Hex): Promise<bigint> {
+    if (!this.hasClientStarted) {
+      logger("error", "Light client has not initialized");
+      return Promise.resolve(BigInt(0));
+    }
+
+    const lock = {
+      codeHash: MLDSA_LOCK.codeHash,
+      hashType: MLDSA_LOCK.hashType,
+      args: lockArgs,
+    };
+    const searchKey: ClientIndexerSearchKeyLike = {
+      scriptType: "lock",
+      script: lock,
+      scriptSearchMode: "prefix",
+      filter: { outputDataLenRange: [0, 1] },
+    };
+    return await this.client.getCellsCapacity(searchKey);
+  }
+
+  /**
    * CKB transfer from the current Quantum Purse address.
    *
    * @param to - The recipient's address.

--- a/src/core/quantum_purse.ts
+++ b/src/core/quantum_purse.ts
@@ -282,7 +282,7 @@ export default class QuantumPurse extends QPSigner {
    * @param setMode The mode to set the scripts (All, Partial, Delete).
    * @throws Error light client is not initialized.
    */
-  public async setSellectiveSyncFilter(spxLockArgsArray: Hex[], startingBlocks: bigint[], setMode: LightClientSetScriptsCommand) {
+  public async setSellectiveSyncFilter(spxLockArgsArray: Hex[], startingBlocks: bigint[], setMode: LightClientSetScriptsCommand, scheme: SigScheme = "sphincs+") {
     if (!this.hasClientStarted) throw new Error("Light client has not initialized");
 
     if (spxLockArgsArray.length !== startingBlocks.length) {
@@ -296,7 +296,9 @@ export default class QuantumPurse extends QPSigner {
 
     const filters: ScriptStatus[] = spxLockArgsArray.map((spxLockArgs, index) => ({
       blockNumber: startingBlocks[index],
-      script: this.getLockScript(spxLockArgs),
+      script: scheme === "mldsa65"
+        ? { codeHash: MLDSA_LOCK.codeHash, hashType: MLDSA_LOCK.hashType, args: spxLockArgs }
+        : this.getLockScript(spxLockArgs),
       scriptType: "lock"
     }));
 
@@ -662,7 +664,7 @@ export default class QuantumPurse extends QPSigner {
       });
 
       const startBlocks = await Promise.all(startBlocksPromises);
-      await this.setSellectiveSyncFilter(lockArgsList, startBlocks, LightClientSetScriptsCommand.All);
+      await this.setSellectiveSyncFilter(lockArgsList, startBlocks, LightClientSetScriptsCommand.All, "mldsa65");
     } finally {
       password.fill(0);
     }

--- a/src/ui/components/account-item/account_item.tsx
+++ b/src/ui/components/account-item/account_item.tsx
@@ -30,6 +30,7 @@ interface AccountItemProps extends React.HTMLAttributes<HTMLLIElement> {
   address: string;
   name: string;
   spxLockArgs: string;
+  scheme?: "sphincs+" | "mldsa65";
   hasTools?: boolean;
   copyable?: boolean;
   showBalance?: boolean;
@@ -40,6 +41,7 @@ export const AccountItem: React.FC<AccountItemProps> = ({
   address,
   name,
   spxLockArgs,
+  scheme = "sphincs+",
   hasTools = true,
   copyable = true,
   showBalance = false,
@@ -82,7 +84,7 @@ export const AccountItem: React.FC<AccountItemProps> = ({
       <li {...props} className={cx(styles.accountItem)}>
         <div
           className="account-info"
-          onClick={() => (!isActive && isWalletPage) && dispatch.wallet.switchAccount({ spxLockArgs })}
+          onClick={() => (!isActive && isWalletPage) && dispatch.wallet.switchAccount({ spxLockArgs, scheme })}
         >
           <p className="name">
             {name}{" "}

--- a/src/ui/components/sphincs-param-set/param_selector.tsx
+++ b/src/ui/components/sphincs-param-set/param_selector.tsx
@@ -1,10 +1,58 @@
-import { Form, Select, Tooltip } from "antd";
+import { Cascader, Form, Tooltip } from "antd";
 import { QuestionCircleOutlined } from "@ant-design/icons";
 import { SpxVariant } from "../../../core/quantum_purse";
 import { useLocation } from "react-router-dom";
 import styles from './param_selector.module.scss';
 
+const WALLET_TYPE_OPTIONS = [
+  {
+    value: "mldsa65",
+    label: "ML-DSA-65 (FIPS 204)",
+    children: [
+      { value: "mldsa65", label: "ML-DSA-65 — Lattice-based, compact signatures" },
+    ],
+  },
+  {
+    value: "sphincs+",
+    label: "SPHINCS+ (FIPS 205)",
+    children: [
+      {
+        value: "128",
+        label: "128-bit security (36-word mnemonic)",
+        children: [
+          { value: SpxVariant.Sha2128S, label: "SHA2_128s — recommended" },
+          { value: SpxVariant.Sha2128F, label: "SHA2_128f — fast signing" },
+          { value: SpxVariant.Shake128S, label: "SHAKE_128s" },
+          { value: SpxVariant.Shake128F, label: "SHAKE_128f" },
+        ],
+      },
+      {
+        value: "192",
+        label: "192-bit security (54-word mnemonic)",
+        children: [
+          { value: SpxVariant.Sha2192S, label: "SHA2_192s" },
+          { value: SpxVariant.Sha2192F, label: "SHA2_192f" },
+          { value: SpxVariant.Shake192S, label: "SHAKE_192s" },
+          { value: SpxVariant.Shake192F, label: "SHAKE_192f" },
+        ],
+      },
+      {
+        value: "256",
+        label: "256-bit security (72-word mnemonic)",
+        children: [
+          { value: SpxVariant.Sha2256S, label: "SHA2_256s" },
+          { value: SpxVariant.Sha2256F, label: "SHA2_256f" },
+          { value: SpxVariant.Shake256S, label: "SHAKE_256s" },
+          { value: SpxVariant.Shake256F, label: "SHAKE_256f" },
+        ],
+      },
+    ],
+  },
+];
+
 const ParamsetSelector: React.FC = () => {
+  const isImport = useLocation().pathname === "/import-wallet";
+
   return (
     <Form.Item
       className={styles.paramsetSelector}
@@ -13,9 +61,9 @@ const ParamsetSelector: React.FC = () => {
           Wallet Type
           <Tooltip
             title={
-              useLocation().pathname === "/import-wallet"
-                ? "What SPHINCS+ parameter set did you back up with the input seed phrase?"
-                : "There are 12 SPHINCS+ parameter sets in total, each will determine your wallet type. Sha2_256s is recommended if you have no reference!"
+              isImport
+                ? "Select the scheme and parameter set you used when creating this wallet."
+                : "Choose your signature scheme. ML-DSA-65 is a lattice-based NIST standard with compact signatures. SPHINCS+ is a hash-based alternative with 12 parameter variants."
             }
           >
             <QuestionCircleOutlined style={{ marginLeft: 8 }} />
@@ -23,34 +71,18 @@ const ParamsetSelector: React.FC = () => {
         </span>
       }
       name="parameterSet"
-      rules={[{ required: true, message: "" }]}
+      rules={[{ required: true, message: "Please select a wallet type" }]}
+      // Cascader returns an array — normalise to the leaf value for the rest of the form
+      getValueFromEvent={(val: (string | number)[]) => val ? val[val.length - 1] : undefined}
     >
-      <Select
+      <Cascader
         size="large"
-        placeholder="Select a wallet type"
-      >
-        <Select.OptGroup label="— ML-DSA-65 (FIPS 204) —">
-          <Select.Option value="mldsa65">ML-DSA-65 ✦ Lattice-based, compact signatures</Select.Option>
-        </Select.OptGroup>
-        <Select.OptGroup label="— SPHINCS+ (FIPS 205) — 128-bit | 36-word mnemonic">
-          <Select.Option value={SpxVariant.Sha2128S}>SHA2_128s</Select.Option>
-          <Select.Option value={SpxVariant.Sha2128F}>SHA2_128f</Select.Option>
-          <Select.Option value={SpxVariant.Shake128S}>SHAKE_128s</Select.Option>
-          <Select.Option value={SpxVariant.Shake128F}>SHAKE_128f</Select.Option>
-        </Select.OptGroup>
-        <Select.OptGroup label="SPHINCS+ — 192-bit | 54-word mnemonic">
-          <Select.Option value={SpxVariant.Sha2192S}>SHA2_192s</Select.Option>
-          <Select.Option value={SpxVariant.Sha2192F}>SHA2_192f</Select.Option>
-          <Select.Option value={SpxVariant.Shake192S}>SHAKE_192s</Select.Option>
-          <Select.Option value={SpxVariant.Shake192F}>SHAKE_192f</Select.Option>
-        </Select.OptGroup>
-        <Select.OptGroup label="SPHINCS+ — 256-bit | 72-word mnemonic">
-          <Select.Option value={SpxVariant.Sha2256S}>SHA2_256s</Select.Option>
-          <Select.Option value={SpxVariant.Sha2256F}>SHA2_256f</Select.Option>
-          <Select.Option value={SpxVariant.Shake256S}>SHAKE_256s</Select.Option>
-          <Select.Option value={SpxVariant.Shake256F}>SHAKE_256f</Select.Option>
-        </Select.OptGroup>
-      </Select>
+        placeholder="Select scheme → variant"
+        options={WALLET_TYPE_OPTIONS}
+        expandTrigger="hover"
+        displayRender={(labels) => labels[labels.length - 1]}
+        style={{ width: "100%" }}
+      />
     </Form.Item>
   );
 };

--- a/src/ui/components/sphincs-param-set/param_selector.tsx
+++ b/src/ui/components/sphincs-param-set/param_selector.tsx
@@ -1,58 +1,10 @@
-import { Cascader, Form, Tooltip } from "antd";
+import { Form, Select, Tooltip } from "antd";
 import { QuestionCircleOutlined } from "@ant-design/icons";
 import { SpxVariant } from "../../../core/quantum_purse";
 import { useLocation } from "react-router-dom";
 import styles from './param_selector.module.scss';
 
-const WALLET_TYPE_OPTIONS = [
-  {
-    value: "mldsa65",
-    label: "ML-DSA-65 (FIPS 204)",
-    children: [
-      { value: "mldsa65", label: "ML-DSA-65 — Lattice-based, compact signatures" },
-    ],
-  },
-  {
-    value: "sphincs+",
-    label: "SPHINCS+ (FIPS 205)",
-    children: [
-      {
-        value: "128",
-        label: "128-bit security (36-word mnemonic)",
-        children: [
-          { value: SpxVariant.Sha2128S, label: "SHA2_128s — recommended" },
-          { value: SpxVariant.Sha2128F, label: "SHA2_128f — fast signing" },
-          { value: SpxVariant.Shake128S, label: "SHAKE_128s" },
-          { value: SpxVariant.Shake128F, label: "SHAKE_128f" },
-        ],
-      },
-      {
-        value: "192",
-        label: "192-bit security (54-word mnemonic)",
-        children: [
-          { value: SpxVariant.Sha2192S, label: "SHA2_192s" },
-          { value: SpxVariant.Sha2192F, label: "SHA2_192f" },
-          { value: SpxVariant.Shake192S, label: "SHAKE_192s" },
-          { value: SpxVariant.Shake192F, label: "SHAKE_192f" },
-        ],
-      },
-      {
-        value: "256",
-        label: "256-bit security (72-word mnemonic)",
-        children: [
-          { value: SpxVariant.Sha2256S, label: "SHA2_256s" },
-          { value: SpxVariant.Sha2256F, label: "SHA2_256f" },
-          { value: SpxVariant.Shake256S, label: "SHAKE_256s" },
-          { value: SpxVariant.Shake256F, label: "SHAKE_256f" },
-        ],
-      },
-    ],
-  },
-];
-
 const ParamsetSelector: React.FC = () => {
-  const isImport = useLocation().pathname === "/import-wallet";
-
   return (
     <Form.Item
       className={styles.paramsetSelector}
@@ -61,9 +13,9 @@ const ParamsetSelector: React.FC = () => {
           Wallet Type
           <Tooltip
             title={
-              isImport
-                ? "Select the scheme and parameter set you used when creating this wallet."
-                : "Choose your signature scheme. ML-DSA-65 is a lattice-based NIST standard with compact signatures. SPHINCS+ is a hash-based alternative with 12 parameter variants."
+              useLocation().pathname === "/import-wallet"
+                ? "What SPHINCS+ parameter set did you back up with the input seed phrase?"
+                : "There are 12 SPHINCS+ parameter sets in total, each will determine your wallet type. Sha2_256s is recommended if you have no reference!"
             }
           >
             <QuestionCircleOutlined style={{ marginLeft: 8 }} />
@@ -71,18 +23,34 @@ const ParamsetSelector: React.FC = () => {
         </span>
       }
       name="parameterSet"
-      rules={[{ required: true, message: "Please select a wallet type" }]}
-      // Cascader returns an array — normalise to the leaf value for the rest of the form
-      getValueFromEvent={(val: (string | number)[]) => val ? val[val.length - 1] : undefined}
+      rules={[{ required: true, message: "" }]}
     >
-      <Cascader
+      <Select
         size="large"
-        placeholder="Select scheme → variant"
-        options={WALLET_TYPE_OPTIONS}
-        expandTrigger="hover"
-        displayRender={(labels) => labels[labels.length - 1]}
-        style={{ width: "100%" }}
-      />
+        placeholder="Select a wallet type"
+      >
+        <Select.OptGroup label="— ML-DSA-65 (FIPS 204) —">
+          <Select.Option value="mldsa65">ML-DSA-65 ✦ Lattice-based, compact signatures</Select.Option>
+        </Select.OptGroup>
+        <Select.OptGroup label="— SPHINCS+ (FIPS 205) — 128-bit | 36-word mnemonic">
+          <Select.Option value={SpxVariant.Sha2128S}>SHA2_128s</Select.Option>
+          <Select.Option value={SpxVariant.Sha2128F}>SHA2_128f</Select.Option>
+          <Select.Option value={SpxVariant.Shake128S}>SHAKE_128s</Select.Option>
+          <Select.Option value={SpxVariant.Shake128F}>SHAKE_128f</Select.Option>
+        </Select.OptGroup>
+        <Select.OptGroup label="SPHINCS+ — 192-bit | 54-word mnemonic">
+          <Select.Option value={SpxVariant.Sha2192S}>SHA2_192s</Select.Option>
+          <Select.Option value={SpxVariant.Sha2192F}>SHA2_192f</Select.Option>
+          <Select.Option value={SpxVariant.Shake192S}>SHAKE_192s</Select.Option>
+          <Select.Option value={SpxVariant.Shake192F}>SHAKE_192f</Select.Option>
+        </Select.OptGroup>
+        <Select.OptGroup label="SPHINCS+ — 256-bit | 72-word mnemonic">
+          <Select.Option value={SpxVariant.Sha2256S}>SHA2_256s</Select.Option>
+          <Select.Option value={SpxVariant.Sha2256F}>SHA2_256f</Select.Option>
+          <Select.Option value={SpxVariant.Shake256S}>SHAKE_256s</Select.Option>
+          <Select.Option value={SpxVariant.Shake256F}>SHAKE_256f</Select.Option>
+        </Select.OptGroup>
+      </Select>
     </Form.Item>
   );
 };

--- a/src/ui/components/sphincs-param-set/param_selector.tsx
+++ b/src/ui/components/sphincs-param-set/param_selector.tsx
@@ -29,10 +29,7 @@ const ParamsetSelector: React.FC = () => {
         size="large"
         placeholder="Select a wallet type"
       >
-        <Select.OptGroup label="— ML-DSA-65 (FIPS 204) —">
-          <Select.Option value="mldsa65">ML-DSA-65 ✦ Lattice-based, compact signatures</Select.Option>
-        </Select.OptGroup>
-        <Select.OptGroup label="— SPHINCS+ (FIPS 205) — 128-bit | 36-word mnemonic">
+        <Select.OptGroup label="SPHINCS+ (FIPS 205) — 128-bit | 36-word mnemonic">
           <Select.Option value={SpxVariant.Sha2128S}>SHA2_128s</Select.Option>
           <Select.Option value={SpxVariant.Sha2128F}>SHA2_128f</Select.Option>
           <Select.Option value={SpxVariant.Shake128S}>SHAKE_128s</Select.Option>

--- a/src/ui/components/sphincs-param-set/param_selector.tsx
+++ b/src/ui/components/sphincs-param-set/param_selector.tsx
@@ -27,21 +27,24 @@ const ParamsetSelector: React.FC = () => {
     >
       <Select
         size="large"
-        placeholder="Select a SPHINCS+ variant"
+        placeholder="Select a wallet type"
       >
-        <Select.OptGroup label="128-bit | 36-word mnemonic">
+        <Select.OptGroup label="— ML-DSA-65 (FIPS 204) —">
+          <Select.Option value="mldsa65">ML-DSA-65 ✦ Lattice-based, compact signatures</Select.Option>
+        </Select.OptGroup>
+        <Select.OptGroup label="— SPHINCS+ (FIPS 205) — 128-bit | 36-word mnemonic">
           <Select.Option value={SpxVariant.Sha2128S}>SHA2_128s</Select.Option>
           <Select.Option value={SpxVariant.Sha2128F}>SHA2_128f</Select.Option>
           <Select.Option value={SpxVariant.Shake128S}>SHAKE_128s</Select.Option>
           <Select.Option value={SpxVariant.Shake128F}>SHAKE_128f</Select.Option>
         </Select.OptGroup>
-        <Select.OptGroup label="192-bit | 54-word mnemonic">
+        <Select.OptGroup label="SPHINCS+ — 192-bit | 54-word mnemonic">
           <Select.Option value={SpxVariant.Sha2192S}>SHA2_192s</Select.Option>
           <Select.Option value={SpxVariant.Sha2192F}>SHA2_192f</Select.Option>
           <Select.Option value={SpxVariant.Shake192S}>SHAKE_192s</Select.Option>
           <Select.Option value={SpxVariant.Shake192F}>SHAKE_192f</Select.Option>
         </Select.OptGroup>
-        <Select.OptGroup label="256-bit | 72-word mnemonic">
+        <Select.OptGroup label="SPHINCS+ — 256-bit | 72-word mnemonic">
           <Select.Option value={SpxVariant.Sha2256S}>SHA2_256s</Select.Option>
           <Select.Option value={SpxVariant.Sha2256F}>SHA2_256f</Select.Option>
           <Select.Option value={SpxVariant.Shake256S}>SHAKE_256s</Select.Option>

--- a/src/ui/pages/CreateWallet/CreateWallet.tsx
+++ b/src/ui/pages/CreateWallet/CreateWallet.tsx
@@ -1,5 +1,5 @@
 import { KeyOutlined, LoadingOutlined, LockOutlined, EyeInvisibleOutlined, EyeOutlined } from "@ant-design/icons";
-import { Button, Checkbox, Flex, Form, Modal } from "antd";
+import { Button, Checkbox, Flex, Form, Modal, Select } from "antd";
 import React, {
   createContext,
   useContext,
@@ -281,9 +281,9 @@ export const StepCreatePassword: React.FC = () => {
       const isMlDsa = parameterSet === "mldsa65";
 
       if (isMlDsa) {
-        // KeyVault instance is required even for ML-DSA — initialise with a
-        // default SPHINCS+ variant so the object exists; it won't be used for signing.
-        QuantumPurse.getInstance().initKeyVault(SpxVariant.Sha2128S);
+        const spxVariant = formValues.spxVariant;
+        QuantumPurse.getInstance().initKeyVault(spxVariant);
+        await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, spxVariant.toString());
       } else if (parameterSet) {
         QuantumPurse.getInstance().initKeyVault(parameterSet);
         await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, parameterSet.toString());
@@ -339,6 +339,40 @@ export const StepCreatePassword: React.FC = () => {
       >
         
         <ParamSetSelectorForm />
+
+        {parameterSet === "mldsa65" && (
+          <Form.Item
+            name="spxVariant"
+            label={
+              <span style={{ color: 'var(--gray-01)' }}>
+                SPHINCS+ Variant (for key storage)
+              </span>
+            }
+            rules={[{ required: true, message: "Please select a SPHINCS+ variant" }]}
+            tooltip="ML-DSA uses the same master seed as SPHINCS+. Pick the variant your key vault will use — you'll need to note it alongside your mnemonic."
+          >
+            <Select size="large" placeholder="Select a SPHINCS+ variant">
+              <Select.OptGroup label="128-bit | 36-word mnemonic">
+                <Select.Option value={SpxVariant.Sha2128S}>SHA2_128s — recommended</Select.Option>
+                <Select.Option value={SpxVariant.Sha2128F}>SHA2_128f</Select.Option>
+                <Select.Option value={SpxVariant.Shake128S}>SHAKE_128s</Select.Option>
+                <Select.Option value={SpxVariant.Shake128F}>SHAKE_128f</Select.Option>
+              </Select.OptGroup>
+              <Select.OptGroup label="192-bit | 54-word mnemonic">
+                <Select.Option value={SpxVariant.Sha2192S}>SHA2_192s</Select.Option>
+                <Select.Option value={SpxVariant.Sha2192F}>SHA2_192f</Select.Option>
+                <Select.Option value={SpxVariant.Shake192S}>SHAKE_192s</Select.Option>
+                <Select.Option value={SpxVariant.Shake192F}>SHAKE_192f</Select.Option>
+              </Select.OptGroup>
+              <Select.OptGroup label="256-bit | 72-word mnemonic">
+                <Select.Option value={SpxVariant.Sha2256S}>SHA2_256s</Select.Option>
+                <Select.Option value={SpxVariant.Sha2256F}>SHA2_256f</Select.Option>
+                <Select.Option value={SpxVariant.Shake256S}>SHAKE_256s</Select.Option>
+                <Select.Option value={SpxVariant.Shake256F}>SHAKE_256f</Select.Option>
+              </Select.OptGroup>
+            </Select>
+          </Form.Item>
+        )}
 
         <div style={{ marginBottom: '1.6rem' }}>
           <label

--- a/src/ui/pages/CreateWallet/CreateWallet.tsx
+++ b/src/ui/pages/CreateWallet/CreateWallet.tsx
@@ -278,23 +278,24 @@ export const StepCreatePassword: React.FC = () => {
     try {
       const parameterSet = formValues.parameterSet;
 
-      if (parameterSet) {
+      const isMlDsa = parameterSet === "mldsa65";
+
+      if (!isMlDsa && parameterSet) {
         QuantumPurse.getInstance().initKeyVault(parameterSet);
-        // store chosen param set to storage, so wallet type retains when refreshed
         await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, parameterSet.toString());
       }
 
-      // Convert to bytes immediately to allow referencing throughout the call stack
-      // each function call to key-vault clears the password bytes buffer, here it is firstly
-      // used to create the wallet then to export the SRP. So clone password for the second call
       passwordBytes = utf8ToBytes(passwordInputRef.current.value);
       clonedPasswordBytes = passwordBytes.slice();
 
-      // input cleaning. Either success or throw.
       passwordInputRef.current.value = '';
       confirmPasswordInputRef.current.value = '';
 
-      await dispatch.wallet.createWallet({ password: passwordBytes });
+      if (isMlDsa) {
+        await dispatch.wallet.createWalletMlDsa({ password: passwordBytes });
+      } else {
+        await dispatch.wallet.createWallet({ password: passwordBytes });
+      }
       srpRef.current = await QuantumPurse.getInstance().exportSeedPhrase(clonedPasswordBytes);
       setSrpRevealed(true);
       next();
@@ -482,7 +483,9 @@ const StepSecureSRP: React.FC = () => {
       title={"Secure Secret Recovery Phrase"}
       description={
         srpRef.current
-          ? "WARNING! Never copy or screenshot!\nOnly handwrite to backup your mnemonic phrase! \n Backup too your chosen SPHINCS+ variant [" + SpxVariant[Number(QuantumPurse.getInstance().getSphincsPlusParamSet())] + "]!"
+          ? QuantumPurse.getInstance().getSphincsPlusParamSet()
+            ? "WARNING! Never copy or screenshot!\nOnly handwrite to backup your mnemonic phrase! \n Backup too your chosen SPHINCS+ variant [" + SpxVariant[Number(QuantumPurse.getInstance().getSphincsPlusParamSet())] + "]!"
+            : "WARNING! Never copy or screenshot!\nOnly handwrite to backup your mnemonic phrase!\nThis wallet uses ML-DSA-65 — no variant to note, just the mnemonic."
           : "Your wallet creation process has been interrupted. Please enter your password to reveal your SRP then follow through the process or reset and start again."
       }
       exportSrpHandler={exportSrpHandler}

--- a/src/ui/pages/CreateWallet/CreateWallet.tsx
+++ b/src/ui/pages/CreateWallet/CreateWallet.tsx
@@ -1,5 +1,5 @@
 import { KeyOutlined, LoadingOutlined, LockOutlined, EyeInvisibleOutlined, EyeOutlined } from "@ant-design/icons";
-import { Button, Checkbox, Flex, Form, Modal, Select } from "antd";
+import { Button, Checkbox, Flex, Form, Modal } from "antd";
 import React, {
   createContext,
   useContext,
@@ -281,9 +281,9 @@ export const StepCreatePassword: React.FC = () => {
       const isMlDsa = parameterSet === "mldsa65";
 
       if (isMlDsa) {
-        const spxVariant = formValues.spxVariant;
-        QuantumPurse.getInstance().initKeyVault(spxVariant);
-        await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, spxVariant.toString());
+        // ML-DSA key derivation is independent of the SPHINCS+ variant — use a fixed default
+        QuantumPurse.getInstance().initKeyVault(SpxVariant.Sha2128S);
+        await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, SpxVariant.Sha2128S.toString());
       } else if (parameterSet) {
         QuantumPurse.getInstance().initKeyVault(parameterSet);
         await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, parameterSet.toString());
@@ -339,40 +339,6 @@ export const StepCreatePassword: React.FC = () => {
       >
         
         <ParamSetSelectorForm />
-
-        {parameterSet === "mldsa65" && (
-          <Form.Item
-            name="spxVariant"
-            label={
-              <span style={{ color: 'var(--gray-01)' }}>
-                SPHINCS+ Variant (for key storage)
-              </span>
-            }
-            rules={[{ required: true, message: "Please select a SPHINCS+ variant" }]}
-            tooltip="ML-DSA uses the same master seed as SPHINCS+. Pick the variant your key vault will use — you'll need to note it alongside your mnemonic."
-          >
-            <Select size="large" placeholder="Select a SPHINCS+ variant">
-              <Select.OptGroup label="128-bit | 36-word mnemonic">
-                <Select.Option value={SpxVariant.Sha2128S}>SHA2_128s — recommended</Select.Option>
-                <Select.Option value={SpxVariant.Sha2128F}>SHA2_128f</Select.Option>
-                <Select.Option value={SpxVariant.Shake128S}>SHAKE_128s</Select.Option>
-                <Select.Option value={SpxVariant.Shake128F}>SHAKE_128f</Select.Option>
-              </Select.OptGroup>
-              <Select.OptGroup label="192-bit | 54-word mnemonic">
-                <Select.Option value={SpxVariant.Sha2192S}>SHA2_192s</Select.Option>
-                <Select.Option value={SpxVariant.Sha2192F}>SHA2_192f</Select.Option>
-                <Select.Option value={SpxVariant.Shake192S}>SHAKE_192s</Select.Option>
-                <Select.Option value={SpxVariant.Shake192F}>SHAKE_192f</Select.Option>
-              </Select.OptGroup>
-              <Select.OptGroup label="256-bit | 72-word mnemonic">
-                <Select.Option value={SpxVariant.Sha2256S}>SHA2_256s</Select.Option>
-                <Select.Option value={SpxVariant.Sha2256F}>SHA2_256f</Select.Option>
-                <Select.Option value={SpxVariant.Shake256S}>SHAKE_256s</Select.Option>
-                <Select.Option value={SpxVariant.Shake256F}>SHAKE_256f</Select.Option>
-              </Select.OptGroup>
-            </Select>
-          </Form.Item>
-        )}
 
         <div style={{ marginBottom: '1.6rem' }}>
           <label

--- a/src/ui/pages/CreateWallet/CreateWallet.tsx
+++ b/src/ui/pages/CreateWallet/CreateWallet.tsx
@@ -280,7 +280,11 @@ export const StepCreatePassword: React.FC = () => {
 
       const isMlDsa = parameterSet === "mldsa65";
 
-      if (!isMlDsa && parameterSet) {
+      if (isMlDsa) {
+        // KeyVault instance is required even for ML-DSA — initialise with a
+        // default SPHINCS+ variant so the object exists; it won't be used for signing.
+        QuantumPurse.getInstance().initKeyVault(SpxVariant.Sha2128S);
+      } else if (parameterSet) {
         QuantumPurse.getInstance().initKeyVault(parameterSet);
         await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, parameterSet.toString());
       }

--- a/src/ui/pages/CreateWalletMlDsa/CreateWalletMlDsa.tsx
+++ b/src/ui/pages/CreateWalletMlDsa/CreateWalletMlDsa.tsx
@@ -9,24 +9,20 @@ import React, {
   useState,
 } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { SrpTextBox } from "../../components";
 import usePasswordValidator from "../../hooks/usePasswordValidator";
 import { Dispatch, RootState } from "../../store";
-import {
-  STORAGE_KEYS,
-  WALLET_STEP,
-  WalletStepEnum,
-  ROUTES
-} from "../../utils/constants";
+import { STORAGE_KEYS, WALLET_STEP, WalletStepEnum, ROUTES } from "../../utils/constants";
 import { cx, formatError } from "../../utils/methods";
-import styles from "./CreateWallet.module.scss";
-import { CreateWalletContextType } from "./interface";
-import ParamSetSelectorForm from "../../components/sphincs-param-set/param_selector";
+import styles from "../CreateWallet/CreateWallet.module.scss";
+import { CreateWalletContextType } from "../CreateWallet/interface";
 import QuantumPurse, { SpxVariant } from "../../../core/quantum_purse";
-import { useNavigate } from "react-router-dom";
 import { DB } from "../../../core/db";
 import { bytesToUtf8, utf8ToBytes } from "../../../core/utils";
+
+// ML-DSA uses a fixed internal KeyVault variant (irrelevant to ML-DSA key derivation)
+const MLDSA_KEYVAULT_DEFAULT = SpxVariant.Sha2128S;
 
 interface ExtendedCreateWalletContextType extends CreateWalletContextType {
   srpRef: React.RefObject<Uint8Array | null>;
@@ -34,7 +30,7 @@ interface ExtendedCreateWalletContextType extends CreateWalletContextType {
   setSrpRevealed: (value: boolean) => void;
 }
 
-const CreateWalletContext = createContext<ExtendedCreateWalletContextType>({
+const CreateWalletMlDsaContext = createContext<ExtendedCreateWalletContextType>({
   currentStep: WALLET_STEP.PASSWORD,
   setCurrentStep: () => {},
   next: () => {},
@@ -46,39 +42,32 @@ const CreateWalletContext = createContext<ExtendedCreateWalletContextType>({
   setSrpRevealed: () => {},
 });
 
-const CreateWalletProvider: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => {
+const CreateWalletMlDsaProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const location = useLocation();
   const [currentStep, setCurrentStep] = useState<WalletStepEnum>(
     location.state?.step || WALLET_STEP.PASSWORD
   );
   const dispatch = useDispatch<Dispatch>();
-  const { createWallet: loadingCreateWallet } =
+  const { createWalletMlDsa: loadingCreateWallet } =
     useSelector((state: RootState) => state.loading.effects.wallet);
-  
+
   const srpRef = useRef<Uint8Array | null>(null);
   const [srpRevealed, setSrpRevealed] = useState(false);
 
   const next = () => {
-    const nextStepIndex =
-      steps.findIndex((step) => step.key === currentStep) + 1;
+    const nextStepIndex = steps.findIndex((step) => step.key === currentStep) + 1;
     setCurrentStep(steps[nextStepIndex].key);
   };
-  
+
   const prev = () => {
-    const prevStepIndex =
-      steps.findIndex((step) => step.key === currentStep) - 1;
+    const prevStepIndex = steps.findIndex((step) => step.key === currentStep) - 1;
     setCurrentStep(steps[prevStepIndex].key);
   };
 
   useEffect(() => {
-    if (location.state?.step) {
-      setCurrentStep(location.state.step);
-    }
+    if (location.state?.step) setCurrentStep(location.state.step);
   }, [location.state?.step]);
 
-  // Cleanup on unmount
   useEffect(() => {
     return () => {
       if (srpRef.current) {
@@ -96,11 +85,7 @@ const CreateWalletProvider: React.FC<{ children: React.ReactNode }> = ({
     } catch (error) {
       Modal.error({
         title: 'Wallet Initialization Failed',
-        content: (
-          <div>
-            <p>{formatError(error)}</p>
-          </div>
-        ),
+        content: <div><p>{formatError(error)}</p></div>,
         centered: true,
         style: { transform: 'scale(0.9)' },
         transitionName: '',
@@ -115,66 +100,41 @@ const CreateWalletProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   };
 
-  const steps = useMemo(
-    () => [
-      {
-        key: WALLET_STEP.PASSWORD,
-        title: "Wallet Type & Password",
-        description: "Choose a SPHINCS+ parameter set and create a password",
-        icon: loadingCreateWallet ? <LoadingOutlined /> : <KeyOutlined />,
-        content: <StepCreatePassword />,
-      },
-      {
-        key: WALLET_STEP.SRP,
-        title: "Secure Secret Recovery Phrase",
-        description: "Back up your SPHINCS+ variant and Mnemonic Seed Phrase",
-        icon: <LockOutlined />,
-        content: <StepSecureSRP />,
-      },
-    ],
-    [loadingCreateWallet]
-  );
+  const steps = useMemo(() => [
+    {
+      key: WALLET_STEP.PASSWORD,
+      title: "Password",
+      description: "Create a password for your ML-DSA-65 wallet",
+      icon: loadingCreateWallet ? <LoadingOutlined /> : <KeyOutlined />,
+      content: <StepCreatePassword />,
+    },
+    {
+      key: WALLET_STEP.SRP,
+      title: "Secret Recovery Phrase",
+      description: "Back up your mnemonic seed phrase",
+      icon: <LockOutlined />,
+      content: <StepSecureSRP />,
+    },
+  ], [loadingCreateWallet]);
 
   return (
-    <CreateWalletContext.Provider
-      value={{
-        steps,
-        currentStep,
-        setCurrentStep,
-        next,
-        prev,
-        done,
-        srpRef,
-        srpRevealed,
-        setSrpRevealed,
-      }}
+    <CreateWalletMlDsaContext.Provider
+      value={{ steps, currentStep, setCurrentStep, next, prev, done, srpRef, srpRevealed, setSrpRevealed }}
     >
       {children}
-    </CreateWalletContext.Provider>
+    </CreateWalletMlDsaContext.Provider>
   );
 };
 
-const CreateWalletContent: React.FC = () => {
-  const { steps, currentStep } = useContext(CreateWalletContext);
-
-  return (
-    <section className={cx(styles.createWallet, "panel")}>
-      <h1>Create A New Wallet</h1>
-      <div>{steps.find((step) => step.key === currentStep)?.content}</div>
-    </section>
-  );
-};
-
-export const StepCreatePassword: React.FC = () => {
+const StepCreatePassword: React.FC = () => {
   const [form] = Form.useForm();
-  const { next, srpRef, setSrpRevealed } = useContext(CreateWalletContext);
+  const { next, srpRef, setSrpRevealed } = useContext(CreateWalletMlDsaContext);
   const values = Form.useWatch([], form);
   const dispatch = useDispatch<Dispatch>();
   const [submittable, setSubmittable] = React.useState<boolean>(false);
-  const { createWallet: loadingCreateWallet } =
+  const { createWalletMlDsa: loadingCreateWallet } =
     useSelector((state: RootState) => state.loading.effects.wallet);
-  const parameterSet = Form.useWatch('parameterSet', form);
-  const { rules: passwordRules } = usePasswordValidator(parameterSet);
+  const { rules: passwordRules } = usePasswordValidator(MLDSA_KEYVAULT_DEFAULT);
   const navigate = useNavigate();
 
   const passwordInputRef = useRef<HTMLInputElement>(null);
@@ -188,10 +148,8 @@ export const StepCreatePassword: React.FC = () => {
 
   useEffect(() => {
     return () => {
-      if (passwordInputRef.current)
-        passwordInputRef.current.value = '';
-      if (confirmPasswordInputRef.current)
-        confirmPasswordInputRef.current.value = '';
+      if (passwordInputRef.current) passwordInputRef.current.value = '';
+      if (confirmPasswordInputRef.current) confirmPasswordInputRef.current.value = '';
     };
   }, []);
 
@@ -202,13 +160,8 @@ export const StepCreatePassword: React.FC = () => {
       .catch(() => setSubmittable(false));
   }, [form, values]);
 
-  useEffect(() => {
-    handlePasswordChange();
-  }, [parameterSet]);
-
   const handlePasswordChange = async () => {
     if (!passwordInputRef.current) return;
-
     setPasswordError('');
     setPasswordWarning('');
 
@@ -218,9 +171,6 @@ export const StepCreatePassword: React.FC = () => {
     }
 
     let hasError = false;
-
-    // Reusing password rules that were previously defined for Ant Form.item
-    // but now plain html input
     for (const rule of passwordRules) {
       try {
         if (rule.validator) {
@@ -252,7 +202,6 @@ export const StepCreatePassword: React.FC = () => {
 
   const handleConfirmPasswordChange = () => {
     if (!passwordInputRef.current || !confirmPasswordInputRef.current) return;
-
     setConfirmPasswordError('');
 
     if (!confirmPasswordInputRef.current.value) {
@@ -261,11 +210,7 @@ export const StepCreatePassword: React.FC = () => {
     }
 
     const passwordsMatch = passwordInputRef.current.value === confirmPasswordInputRef.current.value;
-
-    if (!passwordsMatch) {
-      setConfirmPasswordError('The passwords do not match!');
-    }
-
+    if (!passwordsMatch) setConfirmPasswordError('The passwords do not match!');
     setPasswordsValid(passwordsMatch && !passwordError);
   };
 
@@ -276,12 +221,8 @@ export const StepCreatePassword: React.FC = () => {
     let clonedPasswordBytes: Uint8Array = new Uint8Array(0);
 
     try {
-      const parameterSet = formValues.parameterSet;
-
-      if (parameterSet) {
-        QuantumPurse.getInstance().initKeyVault(parameterSet);
-        await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, parameterSet.toString());
-      }
+      QuantumPurse.getInstance().initKeyVault(MLDSA_KEYVAULT_DEFAULT);
+      await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, MLDSA_KEYVAULT_DEFAULT.toString());
 
       passwordBytes = utf8ToBytes(passwordInputRef.current.value);
       clonedPasswordBytes = passwordBytes.slice();
@@ -289,20 +230,15 @@ export const StepCreatePassword: React.FC = () => {
       passwordInputRef.current.value = '';
       confirmPasswordInputRef.current.value = '';
 
-      await dispatch.wallet.createWallet({ password: passwordBytes });
+      await dispatch.wallet.createWalletMlDsa({ password: passwordBytes });
       srpRef.current = await QuantumPurse.getInstance().exportSeedPhrase(clonedPasswordBytes);
       setSrpRevealed(true);
       next();
       await DB.setItem(STORAGE_KEYS.WALLET_STEP, WALLET_STEP.SRP.toString());
-
     } catch (error) {
       Modal.error({
         title: 'Wallet Creation Failed',
-        content: (
-          <div>
-            <p>{formatError(error)}</p>
-          </div>
-        ),
+        content: <div><p>{formatError(error)}</p></div>,
         centered: true,
         style: { transform: 'scale(0.9)' },
         transitionName: '',
@@ -311,33 +247,20 @@ export const StepCreatePassword: React.FC = () => {
     } finally {
       passwordBytes.fill(0);
       clonedPasswordBytes.fill(0);
-      if(passwordInputRef.current)
-        passwordInputRef.current.value = '';
-      if(confirmPasswordInputRef.current)
-        confirmPasswordInputRef.current.value = '';
+      if (passwordInputRef.current) passwordInputRef.current.value = '';
+      if (confirmPasswordInputRef.current) confirmPasswordInputRef.current.value = '';
     }
   };
 
   return (
     <div className={styles.stepCreatePassword}>
-      <h2>Wallet Type & Password</h2>
-      <Form 
-        form={form} 
-        layout="vertical" 
-        onFinish={onFinish}
-        initialValues={{ parameterSet: SpxVariant.Sha2128S }}
-      >
-        
-        <ParamSetSelectorForm />
-
+      <h2>Password</h2>
+      <p style={{ color: 'var(--gray-01)', marginBottom: '1.6rem', fontSize: '1.4rem' }}>
+        ML-DSA-65 (FIPS 204) — Lattice-based post-quantum signatures, compact and fast.
+      </p>
+      <Form form={form} layout="vertical" onFinish={onFinish} initialValues={{}}>
         <div style={{ marginBottom: '1.6rem' }}>
-          <label
-            style={{
-              color: 'var(--gray-01)',
-              marginBottom: '0.8rem',
-              display: 'block',
-            }}
-          >
+          <label style={{ color: 'var(--gray-01)', marginBottom: '0.8rem', display: 'block' }}>
             <span style={{ color: '#ff4d4f' }}>*</span> Password
           </label>
           <div className={styles.passwordWrapper}>
@@ -364,13 +287,7 @@ export const StepCreatePassword: React.FC = () => {
         </div>
 
         <div style={{ marginBottom: '1.6rem' }}>
-          <label
-            style={{
-              color: 'var(--gray-01)',
-              marginBottom: '0.8rem',
-              display: 'block',
-            }}
-          >
+          <label style={{ color: 'var(--gray-01)', marginBottom: '0.8rem', display: 'block' }}>
             <span style={{ color: '#ff4d4f' }}>*</span> Confirm Password
           </label>
           <div className={styles.passwordWrapper}>
@@ -398,35 +315,23 @@ export const StepCreatePassword: React.FC = () => {
         <Form.Item
           name="walletTypeBackup"
           valuePropName="checked"
-          rules={[
-            {
-              validator: (_, value) =>
-                value
-                  ? Promise.resolve()
-                  : Promise.reject(new Error("You must agree to the terms!")),
-            },
-          ]}
+          rules={[{
+            validator: (_, value) =>
+              value ? Promise.resolve() : Promise.reject(new Error("You must agree to the terms!")),
+          }]}
         >
           <Checkbox style={{ color: 'var(--gray-01)' }}>
-            I understand I must back up my wallet type with the mnemonic phrase next step.
+            I understand I must back up my mnemonic phrase in the next step.
           </Checkbox>
         </Form.Item>
 
         <Form.Item
           name="passwordAwareness"
           valuePropName="checked"
-          rules={[
-            {
-              validator: (_, value) => {
-                if (value) {
-                  return Promise.resolve();
-                }
-                return Promise.reject(
-                  new Error("You must agree to the terms!")
-                );
-              },
-            },
-          ]}
+          rules={[{
+            validator: (_, value) =>
+              value ? Promise.resolve() : Promise.reject(new Error("You must agree to the terms!")),
+          }]}
         >
           <Checkbox style={{ color: 'var(--gray-01)' }}>
             I understand that Quantum Purse cannot recover this password if lost.
@@ -435,10 +340,7 @@ export const StepCreatePassword: React.FC = () => {
 
         <Flex align="center" justify="center" gap={16}>
           <Form.Item>
-            <Button
-              onClick={() => navigate(ROUTES.WELCOME)}
-              disabled={loadingCreateWallet}
-            >
+            <Button onClick={() => navigate(ROUTES.WELCOME)} disabled={loadingCreateWallet}>
               Back
             </Button>
           </Form.Item>
@@ -448,7 +350,7 @@ export const StepCreatePassword: React.FC = () => {
               type="primary"
               disabled={!submittable || !passwordsValid || loadingCreateWallet}
               loading={loadingCreateWallet}
-              style={{color: "var(--black)"}}
+              style={{ color: "var(--black)" }}
             >
               Create
             </Button>
@@ -460,7 +362,7 @@ export const StepCreatePassword: React.FC = () => {
 };
 
 const StepSecureSRP: React.FC = () => {
-  const { done, srpRef, srpRevealed, setSrpRevealed } = useContext(CreateWalletContext);
+  const { done, srpRef, srpRevealed, setSrpRevealed } = useContext(CreateWalletMlDsaContext);
 
   const exportSrpHandler = async (password: Uint8Array) => {
     try {
@@ -477,9 +379,7 @@ const StepSecureSRP: React.FC = () => {
       title={"Secure Secret Recovery Phrase"}
       description={
         srpRef.current
-          ? QuantumPurse.getInstance().getSphincsPlusParamSet()
-            ? "WARNING! Never copy or screenshot!\nOnly handwrite to backup your mnemonic phrase! \n Backup too your chosen SPHINCS+ variant [" + SpxVariant[Number(QuantumPurse.getInstance().getSphincsPlusParamSet())] + "]!"
-            : "WARNING! Never copy or screenshot!\nOnly handwrite to backup your mnemonic phrase!\nThis wallet uses ML-DSA-65 — no variant to note, just the mnemonic."
+          ? "WARNING! Never copy or screenshot!\nOnly handwrite to backup your mnemonic phrase!\nThis wallet uses ML-DSA-65 — no variant to note, just the mnemonic."
           : "Your wallet creation process has been interrupted. Please enter your password to reveal your SRP then follow through the process or reset and start again."
       }
       exportSrpHandler={exportSrpHandler}
@@ -489,12 +389,22 @@ const StepSecureSRP: React.FC = () => {
   );
 };
 
-const CreateWallet: React.FC = () => {
+const CreateWalletMlDsaContent: React.FC = () => {
+  const { steps, currentStep } = useContext(CreateWalletMlDsaContext);
   return (
-    <CreateWalletProvider>
-      <CreateWalletContent />
-    </CreateWalletProvider>
+    <section className={cx(styles.createWallet, "panel")}>
+      <h1>Create An ML-DSA-65 Wallet</h1>
+      <div>{steps.find((step) => step.key === currentStep)?.content}</div>
+    </section>
   );
 };
 
-export default CreateWallet;
+const CreateWalletMlDsa: React.FC = () => {
+  return (
+    <CreateWalletMlDsaProvider>
+      <CreateWalletMlDsaContent />
+    </CreateWalletMlDsaProvider>
+  );
+};
+
+export default CreateWalletMlDsa;

--- a/src/ui/pages/ImportWallet/ImportWallet.tsx
+++ b/src/ui/pages/ImportWallet/ImportWallet.tsx
@@ -6,7 +6,6 @@ import {
   Form,
   FormInstance,
   Modal,
-  Select,
   Tabs,
 } from "antd";
 import React, {
@@ -183,40 +182,6 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
       <h2>Wallet Type & Password</h2>
 
       <ParamSetSelector />
-
-      {parameterSet === "mldsa65" && (
-        <Form.Item
-          name="spxVariant"
-          label={
-            <span style={{ color: 'var(--gray-01)' }}>
-              SPHINCS+ Variant (for key storage)
-            </span>
-          }
-          rules={[{ required: true, message: "Please select the SPHINCS+ variant you used" }]}
-          tooltip="Select the SPHINCS+ variant you chose when creating this wallet — required to reconstruct the key vault."
-        >
-          <Select size="large" placeholder="Select the SPHINCS+ variant you used">
-            <Select.OptGroup label="128-bit | 36-word mnemonic">
-              <Select.Option value={SpxVariant.Sha2128S}>SHA2_128s</Select.Option>
-              <Select.Option value={SpxVariant.Sha2128F}>SHA2_128f</Select.Option>
-              <Select.Option value={SpxVariant.Shake128S}>SHAKE_128s</Select.Option>
-              <Select.Option value={SpxVariant.Shake128F}>SHAKE_128f</Select.Option>
-            </Select.OptGroup>
-            <Select.OptGroup label="192-bit | 54-word mnemonic">
-              <Select.Option value={SpxVariant.Sha2192S}>SHA2_192s</Select.Option>
-              <Select.Option value={SpxVariant.Sha2192F}>SHA2_192f</Select.Option>
-              <Select.Option value={SpxVariant.Shake192S}>SHAKE_192s</Select.Option>
-              <Select.Option value={SpxVariant.Shake192F}>SHAKE_192f</Select.Option>
-            </Select.OptGroup>
-            <Select.OptGroup label="256-bit | 72-word mnemonic">
-              <Select.Option value={SpxVariant.Sha2256S}>SHA2_256s</Select.Option>
-              <Select.Option value={SpxVariant.Sha2256F}>SHA2_256f</Select.Option>
-              <Select.Option value={SpxVariant.Shake256S}>SHAKE_256s</Select.Option>
-              <Select.Option value={SpxVariant.Shake256F}>SHAKE_256f</Select.Option>
-            </Select.OptGroup>
-          </Select>
-        </Form.Item>
-      )}
 
       <div style={{ marginBottom: '1.6rem' }}>
         <label
@@ -447,9 +412,10 @@ const ImportWalletContent: React.FC = () => {
   const onFinish = async (formValues: any) => {
     if (!passwordInputRef.current || !srpInputRef.current || !confirmPasswordInputRef.current) return;
 
-    const { parameterSet, spxVariant } = formValues;
+    const { parameterSet } = formValues;
     const isMlDsa = parameterSet === "mldsa65";
-    const keyVaultVariant = isMlDsa ? spxVariant : parameterSet;
+    // ML-DSA key derivation is independent of the SPHINCS+ variant — use a fixed default
+    const keyVaultVariant = isMlDsa ? SpxVariant.Sha2128S : parameterSet;
 
     QuantumPurse.getInstance().initKeyVault(keyVaultVariant);
     await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, keyVaultVariant.toString());

--- a/src/ui/pages/ImportWallet/ImportWallet.tsx
+++ b/src/ui/pages/ImportWallet/ImportWallet.tsx
@@ -6,6 +6,7 @@ import {
   Form,
   FormInstance,
   Modal,
+  Select,
   Tabs,
 } from "antd";
 import React, {
@@ -182,6 +183,40 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
       <h2>Wallet Type & Password</h2>
 
       <ParamSetSelector />
+
+      {parameterSet === "mldsa65" && (
+        <Form.Item
+          name="spxVariant"
+          label={
+            <span style={{ color: 'var(--gray-01)' }}>
+              SPHINCS+ Variant (for key storage)
+            </span>
+          }
+          rules={[{ required: true, message: "Please select the SPHINCS+ variant you used" }]}
+          tooltip="Select the SPHINCS+ variant you chose when creating this wallet — required to reconstruct the key vault."
+        >
+          <Select size="large" placeholder="Select the SPHINCS+ variant you used">
+            <Select.OptGroup label="128-bit | 36-word mnemonic">
+              <Select.Option value={SpxVariant.Sha2128S}>SHA2_128s</Select.Option>
+              <Select.Option value={SpxVariant.Sha2128F}>SHA2_128f</Select.Option>
+              <Select.Option value={SpxVariant.Shake128S}>SHAKE_128s</Select.Option>
+              <Select.Option value={SpxVariant.Shake128F}>SHAKE_128f</Select.Option>
+            </Select.OptGroup>
+            <Select.OptGroup label="192-bit | 54-word mnemonic">
+              <Select.Option value={SpxVariant.Sha2192S}>SHA2_192s</Select.Option>
+              <Select.Option value={SpxVariant.Sha2192F}>SHA2_192f</Select.Option>
+              <Select.Option value={SpxVariant.Shake192S}>SHAKE_192s</Select.Option>
+              <Select.Option value={SpxVariant.Shake192F}>SHAKE_192f</Select.Option>
+            </Select.OptGroup>
+            <Select.OptGroup label="256-bit | 72-word mnemonic">
+              <Select.Option value={SpxVariant.Sha2256S}>SHA2_256s</Select.Option>
+              <Select.Option value={SpxVariant.Sha2256F}>SHA2_256f</Select.Option>
+              <Select.Option value={SpxVariant.Shake256S}>SHAKE_256s</Select.Option>
+              <Select.Option value={SpxVariant.Shake256F}>SHAKE_256f</Select.Option>
+            </Select.OptGroup>
+          </Select>
+        </Form.Item>
+      )}
 
       <div style={{ marginBottom: '1.6rem' }}>
         <label
@@ -409,34 +444,35 @@ const ImportWalletContent: React.FC = () => {
     };
   }, []);
 
-  const onFinish = async ({ parameterSet }: { parameterSet: SpxVariant }) => {
+  const onFinish = async (formValues: any) => {
     if (!passwordInputRef.current || !srpInputRef.current || !confirmPasswordInputRef.current) return;
 
-    QuantumPurse.getInstance().initKeyVault(parameterSet);
-    // store chosen param set to storage, so wallet type retains when refreshed
-    await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, parameterSet.toString());
+    const { parameterSet, spxVariant } = formValues;
+    const isMlDsa = parameterSet === "mldsa65";
+    const keyVaultVariant = isMlDsa ? spxVariant : parameterSet;
+
+    QuantumPurse.getInstance().initKeyVault(keyVaultVariant);
+    await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, keyVaultVariant.toString());
 
     let srpBytes: Uint8Array = new Uint8Array(0);
     let passwordBytes: Uint8Array = new Uint8Array(0);
     try {
-      // Convert to bytes immediately to allow referencing throughout the call stack
-      // if fail, inputs are highly not valid, so no clean up needed -> let users edit inputs again.
       srpBytes = utf8ToBytes(srpInputRef.current.value);
       passwordBytes = utf8ToBytes(passwordInputRef.current.value);
 
-      // if the following line successes, clear the input references. If not, allow to edit inputs again.
-      await dispatch.wallet.importWallet({ srp: srpBytes, password: passwordBytes });
+      if (isMlDsa) {
+        await dispatch.wallet.importWalletMlDsa({ srp: srpBytes, password: passwordBytes });
+      } else {
+        await dispatch.wallet.importWallet({ srp: srpBytes, password: passwordBytes });
+      }
 
-      // input cleaning. Either success or throw.
       srpInputRef.current.value = '';
       passwordInputRef.current.value = '';
       confirmPasswordInputRef.current.value = '';
 
-      // success, procees to load the wallet
       await dispatch.wallet.init({});
       await dispatch.wallet.loadCurrentAccount({});
     } catch (error) {
-
       Modal.error({
         title: 'Import Wallet Failed',
         content: (
@@ -450,7 +486,6 @@ const ImportWalletContent: React.FC = () => {
         maskTransitionName: '',
       });
       return;
-
     } finally {
       srpBytes.fill(0);
       passwordBytes.fill(0);

--- a/src/ui/pages/ImportWalletMlDsa/ImportWalletMlDsa.tsx
+++ b/src/ui/pages/ImportWalletMlDsa/ImportWalletMlDsa.tsx
@@ -1,13 +1,5 @@
 import { KeyOutlined, LoadingOutlined, LockOutlined, EyeInvisibleOutlined, EyeOutlined } from "@ant-design/icons";
-import {
-  Button,
-  Checkbox,
-  Flex,
-  Form,
-  FormInstance,
-  Modal,
-  Tabs,
-} from "antd";
+import { Button, Checkbox, Flex, Form, FormInstance, Modal, Tabs } from "antd";
 import React, {
   createContext,
   useContext,
@@ -17,72 +9,71 @@ import React, {
   useState,
 } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import usePasswordValidator from "../../hooks/usePasswordValidator";
 import { Dispatch, RootState } from "../../store";
 import { WalletStepEnum, STORAGE_KEYS, ROUTES } from "../../utils/constants";
 import { cx, formatError } from "../../utils/methods";
-import styles from "./ImportWallet.module.scss";
-import ParamSetSelector from "../../components/sphincs-param-set/param_selector";
-import QuantumPurse from "../../../core/quantum_purse";
-import { useNavigate } from "react-router-dom";
+import styles from "../ImportWallet/ImportWallet.module.scss";
+import QuantumPurse, { SpxVariant } from "../../../core/quantum_purse";
 import { DB } from "../../../core/db";
 import { utf8ToBytes } from "../../../core/utils";
 import { IS_MAIN_NET } from "../../../core/config";
 
-interface ImportWalletContext {
-  currentStep?: WalletStepEnum;
-  next: () => void;
-  prev: () => void;
-}
-
-const ImportWalletContext = createContext<ImportWalletContext>({
-  currentStep: undefined,
-  next: () => {},
-  prev: () => {},
-});
+// ML-DSA uses a fixed internal KeyVault variant (irrelevant to ML-DSA key derivation)
+const MLDSA_KEYVAULT_DEFAULT = SpxVariant.Sha2128S;
 
 const STEP = {
   SRP: 1,
   PASSWORD: 2,
 };
 
-const ImportWalletProvider: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => {
+interface ImportMlDsaContext {
+  currentStep?: WalletStepEnum;
+  next: () => void;
+  prev: () => void;
+}
+
+const ImportWalletMlDsaContext = createContext<ImportMlDsaContext>({
+  currentStep: undefined,
+  next: () => {},
+  prev: () => {},
+});
+
+const ImportWalletMlDsaProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const location = useLocation();
   const [currentStep, setCurrentStep] = useState<WalletStepEnum>(
     location.state?.step || STEP.SRP
   );
 
-  const next = () => {
-    setCurrentStep(currentStep + 1);
-  };
-  const prev = () => {
-    setCurrentStep(currentStep - 1);
-  };
+  const next = () => setCurrentStep(currentStep + 1);
+  const prev = () => setCurrentStep(currentStep - 1);
 
   useEffect(() => {
-    if (location.state?.step) {
-      setCurrentStep(location.state.step);
-    }
+    if (location.state?.step) setCurrentStep(location.state.step);
   }, [location.state?.step]);
 
   return (
-    <ImportWalletContext.Provider value={{ currentStep, next, prev }}>
+    <ImportWalletMlDsaContext.Provider value={{ currentStep, next, prev }}>
       {children}
-    </ImportWalletContext.Provider>
+    </ImportWalletMlDsaContext.Provider>
   );
 };
 
-export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInputRef, confirmPasswordInputRef }) => {
+interface BaseStepProps {
+  form: FormInstance;
+  passwordInputRef?: React.RefObject<HTMLInputElement | null>;
+  confirmPasswordInputRef?: React.RefObject<HTMLInputElement | null>;
+  srpInputRef?: React.RefObject<HTMLTextAreaElement | null>;
+}
+
+const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInputRef, confirmPasswordInputRef }) => {
   const values = Form.useWatch([], form);
   const [submittable, setSubmittable] = React.useState<boolean>(false);
-  const { importWallet: loadingImportWallet } =
+  const { importWalletMlDsa: loadingImport } =
     useSelector((state: RootState) => state.loading.effects.wallet);
-  const { prev } = useContext(ImportWalletContext);
-  const parameterSet = Form.useWatch("parameterSet", form);
-  const { rules: passwordRules } = usePasswordValidator(parameterSet);
+  const { prev } = useContext(ImportWalletMlDsaContext);
+  const { rules: passwordRules } = usePasswordValidator(MLDSA_KEYVAULT_DEFAULT);
 
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -96,24 +87,15 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
       try {
         await form.validateFields({ validateOnly: true });
         setSubmittable(true);
-      } catch (e:any) {
-        if (e.errorFields?.length === 0) {
-          setSubmittable(true);
-        } else {
-          setSubmittable(false);
-        }
+      } catch (e: any) {
+        setSubmittable(e.errorFields?.length === 0);
       }
     };
     validate();
   }, [form, values]);
 
-  useEffect(() => {
-    handlePasswordChange();
-  }, [parameterSet]);
-
   const handlePasswordChange = async () => {
     if (!passwordInputRef?.current) return;
-
     setPasswordError('');
     setPasswordWarning('');
 
@@ -123,7 +105,6 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
     }
 
     let hasError = false;
-
     for (const rule of passwordRules) {
       try {
         if (rule.validator) {
@@ -155,7 +136,6 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
 
   const handleConfirmPasswordChange = () => {
     if (!passwordInputRef?.current || !confirmPasswordInputRef?.current) return;
-
     setConfirmPasswordError('');
 
     if (!confirmPasswordInputRef.current.value) {
@@ -164,33 +144,19 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
     }
 
     const passwordsMatch = passwordInputRef.current.value === confirmPasswordInputRef.current.value;
-
-    if (!passwordsMatch) {
-      setConfirmPasswordError('The passwords do not match!');
-    }
-
+    if (!passwordsMatch) setConfirmPasswordError('The passwords do not match!');
     setPasswordsValid(passwordsMatch && !passwordError);
-  };
-
-  const handleImportClick = () => {
-    // Don't clear password inputs here - we'll need them in onFinish
-    form.submit();
   };
 
   return (
     <div className={styles.stepCreatePassword}>
-      <h2>Wallet Type & Password</h2>
-
-      <ParamSetSelector />
+      <h2>Password</h2>
+      <p style={{ color: 'var(--gray-01)', marginBottom: '1.6rem', fontSize: '1.4rem' }}>
+        ML-DSA-65 (FIPS 204) — Lattice-based post-quantum signatures, compact and fast.
+      </p>
 
       <div style={{ marginBottom: '1.6rem' }}>
-        <label
-          style={{
-            color: 'var(--gray-01)',
-            marginBottom: '0.8rem',
-            display: 'block',
-          }}
-        >
+        <label style={{ color: 'var(--gray-01)', marginBottom: '0.8rem', display: 'block' }}>
           <span style={{ color: '#ff4d4f' }}>*</span> Password
         </label>
         <div className={styles.passwordWrapper}>
@@ -198,7 +164,7 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
             ref={passwordInputRef}
             type={showPassword ? 'text' : 'password'}
             placeholder="Please choose a strong password"
-            disabled={loadingImportWallet}
+            disabled={loadingImport}
             className={styles.passwordInput}
             onChange={handlePasswordChange}
           />
@@ -206,7 +172,7 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
             type="button"
             className={styles.toggleButton}
             onClick={() => setShowPassword(!showPassword)}
-            disabled={loadingImportWallet}
+            disabled={loadingImport}
             tabIndex={-1}
           >
             {showPassword ? <EyeOutlined /> : <EyeInvisibleOutlined />}
@@ -217,21 +183,15 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
       </div>
 
       <div style={{ marginBottom: '1.6rem' }}>
-          <label
-            style={{
-              color: 'var(--gray-01)',
-              marginBottom: '0.8rem',
-              display: 'block',
-            }}
-          >
-            <span style={{ color: '#ff4d4f' }}>*</span> Confirm Password
-          </label>
+        <label style={{ color: 'var(--gray-01)', marginBottom: '0.8rem', display: 'block' }}>
+          <span style={{ color: '#ff4d4f' }}>*</span> Confirm Password
+        </label>
         <div className={styles.passwordWrapper}>
           <input
             ref={confirmPasswordInputRef}
             type={showConfirmPassword ? 'text' : 'password'}
             placeholder="Confirm your password"
-            disabled={loadingImportWallet}
+            disabled={loadingImport}
             className={styles.passwordInput}
             onChange={handleConfirmPasswordChange}
           />
@@ -239,7 +199,7 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
             type="button"
             className={styles.toggleButton}
             onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-            disabled={loadingImportWallet}
+            disabled={loadingImport}
             tabIndex={-1}
           >
             {showConfirmPassword ? <EyeOutlined /> : <EyeInvisibleOutlined />}
@@ -249,37 +209,12 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
       </div>
 
       <Form.Item
-        name="walletTypeBackup"
-        valuePropName="checked"
-        rules={[
-          {
-            validator: (_, value) =>
-              value
-                ? Promise.resolve()
-                : Promise.reject(
-                    new Error("You must acknowledge this statement!")
-                  ),
-          },
-        ]}
-      >
-        <Checkbox style={{ color: "var(--gray-01)" }}>
-          I understand that the wallet type must be the one I backed up with the mnemonic phrase I input earlier.
-        </Checkbox>
-      </Form.Item>
-
-      <Form.Item
         name="passwordAwareness"
         valuePropName="checked"
-        rules={[
-          {
-            validator: (_, value) =>
-              value
-                ? Promise.resolve()
-                : Promise.reject(
-                    new Error("You must acknowledge this statement!")
-                  ),
-          },
-        ]}
+        rules={[{
+          validator: (_, value) =>
+            value ? Promise.resolve() : Promise.reject(new Error("You must acknowledge this statement!")),
+        }]}
       >
         <Checkbox style={{ color: "var(--gray-01)" }}>
           I understand that Quantum Purse cannot recover this password if lost.
@@ -288,19 +223,14 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
 
       <Flex align="center" justify="center" gap={16}>
         <Form.Item>
-          <Button
-            onClick={() => prev()}
-            disabled={loadingImportWallet}
-          >
-            Back
-          </Button>
+          <Button onClick={() => prev()} disabled={loadingImport}>Back</Button>
         </Form.Item>
         <Form.Item>
           <Button
             type="primary"
-            onClick={handleImportClick}
-            disabled={!submittable || !passwordsValid || loadingImportWallet}
-            loading={loadingImportWallet}
+            onClick={() => form.submit()}
+            disabled={!submittable || !passwordsValid || loadingImport}
+            loading={loadingImport}
           >
             Import
           </Button>
@@ -310,22 +240,14 @@ export const StepCreatePassword: React.FC<BaseStepProps> = ({ form, passwordInpu
   );
 };
 
-interface BaseStepProps {
-  form: FormInstance;
-  passwordInputRef?: React.RefObject<HTMLInputElement | null>;
-  confirmPasswordInputRef?: React.RefObject<HTMLInputElement | null>;
-  srpInputRef?: React.RefObject<HTMLTextAreaElement | null>;
-}
-
 const StepInputSrp: React.FC<BaseStepProps> = ({ form, srpInputRef }) => {
   const [submittable, setSubmittable] = React.useState<boolean>(false);
   const [srpError, setSrpError] = React.useState<string>('');
-  const { next } = useContext(ImportWalletContext);
+  const { next } = useContext(ImportWalletMlDsaContext);
   const navigate = useNavigate();
 
   const handleSrpChange = () => {
     if (!srpInputRef?.current) return;
-
     setSrpError('');
 
     if (!srpInputRef.current.value) {
@@ -335,8 +257,8 @@ const StepInputSrp: React.FC<BaseStepProps> = ({ form, srpInputRef }) => {
 
     let wordCount = 0;
     let inWord = false;
-    for (let i = 0; i < srpInputRef?.current?.value?.length; i++) {
-      const char = srpInputRef?.current?.value[i];
+    for (let i = 0; i < srpInputRef.current.value.length; i++) {
+      const char = srpInputRef.current.value[i];
       const isSpace = char === ' ' || char === '\t' || char === '\n' || char === '\r';
       if (!isSpace && !inWord) {
         wordCount++;
@@ -353,10 +275,6 @@ const StepInputSrp: React.FC<BaseStepProps> = ({ form, srpInputRef }) => {
     }
 
     setSubmittable(true);
-  };
-
-  const handleNextClick = () => {
-    next();
   };
 
   return (
@@ -381,9 +299,7 @@ const StepInputSrp: React.FC<BaseStepProps> = ({ form, srpInputRef }) => {
           <Button
             type="primary"
             disabled={!submittable}
-            loading={false}
-            onClick={handleNextClick}
-            className="next-button"
+            onClick={() => next()}
           >
             Next
           </Button>
@@ -393,7 +309,7 @@ const StepInputSrp: React.FC<BaseStepProps> = ({ form, srpInputRef }) => {
   );
 };
 
-const ImportWalletContent: React.FC = () => {
+const ImportWalletMlDsaContent: React.FC = () => {
   const [form] = Form.useForm();
   const dispatch = useDispatch<Dispatch>();
 
@@ -412,10 +328,8 @@ const ImportWalletContent: React.FC = () => {
   const onFinish = async (formValues: any) => {
     if (!passwordInputRef.current || !srpInputRef.current || !confirmPasswordInputRef.current) return;
 
-    const { parameterSet } = formValues;
-
-    QuantumPurse.getInstance().initKeyVault(parameterSet);
-    await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, parameterSet.toString());
+    QuantumPurse.getInstance().initKeyVault(MLDSA_KEYVAULT_DEFAULT);
+    await DB.setItem(STORAGE_KEYS.SPHINCS_PLUS_PARAM_SET, MLDSA_KEYVAULT_DEFAULT.toString());
 
     let srpBytes: Uint8Array = new Uint8Array(0);
     let passwordBytes: Uint8Array = new Uint8Array(0);
@@ -423,7 +337,7 @@ const ImportWalletContent: React.FC = () => {
       srpBytes = utf8ToBytes(srpInputRef.current.value);
       passwordBytes = utf8ToBytes(passwordInputRef.current.value);
 
-      await dispatch.wallet.importWallet({ srp: srpBytes, password: passwordBytes });
+      await dispatch.wallet.importWalletMlDsa({ srp: srpBytes, password: passwordBytes });
 
       srpInputRef.current.value = '';
       passwordInputRef.current.value = '';
@@ -434,11 +348,7 @@ const ImportWalletContent: React.FC = () => {
     } catch (error) {
       Modal.error({
         title: 'Import Wallet Failed',
-        content: (
-          <div>
-            <p>{formatError(error)}</p>
-          </div>
-        ),
+        content: <div><p>{formatError(error)}</p></div>,
         centered: true,
         style: { transform: 'scale(0.9)' },
         transitionName: '',
@@ -451,34 +361,28 @@ const ImportWalletContent: React.FC = () => {
     }
   };
 
-  const { currentStep } = useContext(ImportWalletContext);
-  const { importWallet: loadingImportWallet } =
+  const { currentStep } = useContext(ImportWalletMlDsaContext);
+  const { importWalletMlDsa: loadingImport } =
     useSelector((state: RootState) => state.loading.effects.wallet);
 
-  const steps = useMemo(
-    () => [
-      {
-        key: STEP.SRP,
-        title: "Import SRP",
-        description: "Import your secret recovery phrase",
-        icon: <LockOutlined />,
-        content: <StepInputSrp form={form} srpInputRef={srpInputRef} />,
-      },
-      {
-        key: STEP.PASSWORD,
-        title: "Wallet Type & Password",
-        description: "Choose SPHINCS+ variant and create password",
-        icon: loadingImportWallet ? <LoadingOutlined /> : <KeyOutlined />,
-        content: <StepCreatePassword form={form} passwordInputRef={passwordInputRef} confirmPasswordInputRef={confirmPasswordInputRef} />,
-      },
-    ],
-    [loadingImportWallet]
-  );
+  const steps = useMemo(() => [
+    {
+      key: STEP.SRP,
+      title: "Import SRP",
+      icon: <LockOutlined />,
+      content: <StepInputSrp form={form} srpInputRef={srpInputRef} />,
+    },
+    {
+      key: STEP.PASSWORD,
+      title: "Password",
+      icon: loadingImport ? <LoadingOutlined /> : <KeyOutlined />,
+      content: <StepCreatePassword form={form} passwordInputRef={passwordInputRef} confirmPasswordInputRef={confirmPasswordInputRef} />,
+    },
+  ], [loadingImport]);
 
   return (
     <section className={cx(styles.importWallet, "panel")}>
-      <h1>Import A Wallet</h1>
-      {/* <Steps current={currentStep} items={steps} /> */}
+      <h1>Import An ML-DSA-65 Wallet</h1>
       <Form form={form} layout="vertical" onFinish={onFinish}>
         <Tabs
           items={steps.map((step) => ({
@@ -495,12 +399,12 @@ const ImportWalletContent: React.FC = () => {
   );
 };
 
-const ImportWallet: React.FC = () => {
+const ImportWalletMlDsa: React.FC = () => {
   return (
-    <ImportWalletProvider>
-      <ImportWalletContent />
-    </ImportWalletProvider>
+    <ImportWalletMlDsaProvider>
+      <ImportWalletMlDsaContent />
+    </ImportWalletMlDsaProvider>
   );
 };
 
-export default ImportWallet;
+export default ImportWalletMlDsa;

--- a/src/ui/pages/Send/Send.tsx
+++ b/src/ui/pages/Send/Send.tsx
@@ -78,6 +78,7 @@ const Send: React.FC = () => {
     const getBalance = async () => {
       const balance = await dispatch.wallet.getAccountBalance({
         spxLockArgs: wallet.current!.spxLockArgs,
+        scheme: wallet.current?.scheme,
       });
       setFromAccountBalance(balance);
     };

--- a/src/ui/pages/Settings/Accounts/Accounts.tsx
+++ b/src/ui/pages/Settings/Accounts/Accounts.tsx
@@ -81,7 +81,7 @@ const Accounts: React.FC = () => {
 
     return (
       <ul className="account-container">
-        {filteredAccounts.map(({ address, name, spxLockArgs }, index) => (
+        {filteredAccounts.map(({ address, name, spxLockArgs, scheme }, index) => (
           <React.Fragment key={spxLockArgs}>
             {index > 0 && (
               <Divider className="divider" key={`divider-${index}`} />
@@ -91,6 +91,7 @@ const Accounts: React.FC = () => {
               address={address!}
               name={name}
               spxLockArgs={spxLockArgs}
+              scheme={scheme}
               isLoading={loadingSwitchAccount}
             />
           </React.Fragment>

--- a/src/ui/pages/Settings/Accounts/Accounts.tsx
+++ b/src/ui/pages/Settings/Accounts/Accounts.tsx
@@ -5,9 +5,10 @@ import {
   Flex,
   Input,
   Modal,
+  Segmented,
   Spin,
 } from "antd";
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   Authentication,
@@ -15,6 +16,7 @@ import {
 } from "../../../components";
 import { useAccountSearch } from "../../../hooks/useAccountSearch";
 import { Dispatch, RootState } from "../../../store";
+import { SigScheme } from "../../../store/models/interface";
 import { cx, formatError } from "../../../utils/methods";
 import styles from "./Accounts.module.scss";
 import { AccountItem } from "../../../components/account-item/account_item";
@@ -24,6 +26,7 @@ const Accounts: React.FC = () => {
   const wallet = useSelector((state: RootState) => state.wallet);
   const {
     createAccount: loadingCreateAccount,
+    createMlDsaAccount: loadingCreateMlDsaAccount,
     loadAccounts: loadingLoadAccounts,
     switchAccount: loadingSwitchAccount,
   } = useSelector((state: RootState) => state.loading.effects.wallet);
@@ -32,10 +35,17 @@ const Accounts: React.FC = () => {
     useAccountSearch(wallet.accounts);
 
   const authenticationRef = useRef<AuthenticationRef>(null);
+  const [selectedScheme, setSelectedScheme] = useState<SigScheme>("sphincs+");
+
+  const isCreating = loadingCreateAccount || loadingCreateMlDsaAccount;
 
   const createAccountHandler = async (password: Uint8Array) => {
     try {
-      await dispatch.wallet.createAccount({ password });
+      if (selectedScheme === "mldsa65") {
+        await dispatch.wallet.createMlDsaAccount({ password });
+      } else {
+        await dispatch.wallet.createAccount({ password });
+      }
     } catch (error) {
       Modal.error({
         title: 'Failed to Create Account',
@@ -97,7 +107,7 @@ const Accounts: React.FC = () => {
         justify="space-between"
         align="center"
         gap={8}
-        style={{ marginBottom: 16, marginTop: 4 }}
+        style={{ marginBottom: 8, marginTop: 4 }}
       >
         <Input.Search
           placeholder="Search by name or address"
@@ -110,11 +120,22 @@ const Accounts: React.FC = () => {
         <Button
           type="primary"
           onClick={() => authenticationRef.current?.open()}
-          loading={loadingCreateAccount}
-          disabled={loadingCreateAccount || loadingLoadAccounts}
+          loading={isCreating}
+          disabled={isCreating || loadingLoadAccounts}
         >
           Gen New Account
         </Button>
+      </Flex>
+      <Flex justify="flex-end" style={{ marginBottom: 16 }}>
+        <Segmented
+          value={selectedScheme}
+          onChange={(v) => setSelectedScheme(v as SigScheme)}
+          options={[
+            { label: "SPHINCS+", value: "sphincs+" },
+            { label: "ML-DSA-65", value: "mldsa65" },
+          ]}
+          size="small"
+        />
       </Flex>
       <div className={styles.accountListContainer}>
         <Spin size="large" spinning={loadingLoadAccounts}>

--- a/src/ui/pages/Welcome/Welcome.tsx
+++ b/src/ui/pages/Welcome/Welcome.tsx
@@ -30,11 +30,21 @@ const Welcome: React.FC = () => {
     <section className={styles.welcome}>
       <h1>Welcome to Quantum Purse</h1>
       <p>Lightweight Client Wallet, Post-Quantum Hardened, Powered by CKB.</p>
+
+      <p style={{ marginTop: '1.6rem', marginBottom: '0.4rem', fontWeight: 600 }}>SPHINCS+ (FIPS 205)</p>
       <Button onClick={() => navigate(ROUTES.CREATE_WALLET, {replace: true})}>
         Create a New Wallet
       </Button>
       <Button onClick={() => navigate(ROUTES.IMPORT_WALLET, {replace: true})}>
         Import a Wallet Seed
+      </Button>
+
+      <p style={{ marginTop: '2rem', marginBottom: '0.4rem', fontWeight: 600 }}>ML-DSA-65 (FIPS 204)</p>
+      <Button onClick={() => navigate(ROUTES.CREATE_WALLET_MLDSA, {replace: true})}>
+        Create an ML-DSA-65 Wallet
+      </Button>
+      <Button onClick={() => navigate(ROUTES.IMPORT_WALLET_MLDSA, {replace: true})}>
+        Import an ML-DSA-65 Wallet
       </Button>
     </section>
   );

--- a/src/ui/pages/index.tsx
+++ b/src/ui/pages/index.tsx
@@ -1,6 +1,8 @@
 export { default as Welcome } from "./Welcome/Welcome";
 export { default as CreateWallet } from "./CreateWallet/CreateWallet";
 export { default as ImportWallet } from "./ImportWallet/ImportWallet";
+export { default as CreateWalletMlDsa } from "./CreateWalletMlDsa/CreateWalletMlDsa";
+export { default as ImportWalletMlDsa } from "./ImportWalletMlDsa/ImportWalletMlDsa";
 export { default as Receive } from "./Receive/Receive";
 export { default as Send } from "./Send/Send";
 export { default as Deposit } from "./DAO/Deposit/Deposit";

--- a/src/ui/store/models/interface.ts
+++ b/src/ui/store/models/interface.ts
@@ -1,7 +1,13 @@
+/** Signature scheme used by an account. Absent / undefined means "sphincs+" for backward compatibility. */
+export type SigScheme = "sphincs+" | "mldsa65";
+
 interface IAccount {
   name: string;
   address: string | null;
+  /** Hex-encoded lock script args. 64 hex chars (32 B) for SPHINCS+; 72 hex chars (36 B) for ML-DSA-65. */
   spxLockArgs: string;
+  /** Which post-quantum signature scheme this account uses. Defaults to "sphincs+" when absent. */
+  sigScheme?: SigScheme;
 }
 
 interface CurrentAccount extends IAccount {

--- a/src/ui/store/models/wallet.ts
+++ b/src/ui/store/models/wallet.ts
@@ -207,14 +207,23 @@ export const wallet = createModel<RootModel>()({
       }
     },
     async createWallet({ password }) {
-      // each function call to key-vault clears the password bytes buffer,
-      // here it is firstly used to generate the main wallet seed the to generate the first default account
-      // so clone password for the second call
       let clonedPassword: Uint8Array = new Uint8Array(0);
       try {
         clonedPassword = password.slice();
         await quantum.generateMasterSeed(password);
         await quantum.genAccount(clonedPassword);
+        this.loadCurrentAccount({});
+      } finally {
+        password.fill(0);
+        clonedPassword.fill(0);
+      }
+    },
+    async createWalletMlDsa({ password }) {
+      let clonedPassword: Uint8Array = new Uint8Array(0);
+      try {
+        clonedPassword = password.slice();
+        await quantum.generateMasterSeed(password);
+        await quantum.genMlDsa65Account(clonedPassword);
         this.loadCurrentAccount({});
       } finally {
         password.fill(0);

--- a/src/ui/store/models/wallet.ts
+++ b/src/ui/store/models/wallet.ts
@@ -90,12 +90,24 @@ export const wallet = createModel<RootModel>()({
     async loadAccounts() {
       if (!quantum) return;
       try {
-        const accounts = await quantum.getAllLockScriptArgs();
-        const accountsData = accounts.map((account, index) => ({
-          name: `Account ${index + 1}`,
-          spxLockArgs: account,
-          address: quantum.getAddress(account as Hex),
+        const spxAccounts = await quantum.getAllLockScriptArgs();
+        const mlDsaAccounts = await quantum.getAllMlDsaLockArgs();
+
+        const spxData = spxAccounts.map((lockArgs, index) => ({
+          name: `SPHINCS+ Account ${index + 1}`,
+          spxLockArgs: lockArgs,
+          address: quantum.getAddress(lockArgs as Hex, "sphincs+"),
+          scheme: "sphincs+" as const,
         }));
+
+        const mlDsaData = mlDsaAccounts.map((lockArgs, index) => ({
+          name: `ML-DSA-65 Account ${index + 1}`,
+          spxLockArgs: lockArgs,
+          address: quantum.getAddress(lockArgs as Hex, "mldsa65"),
+          scheme: "mldsa65" as const,
+        }));
+
+        const accountsData = [...spxData, ...mlDsaData];
         this.setAccounts(accountsData);
         return accountsData;
       } catch (error) {

--- a/src/ui/store/models/wallet.ts
+++ b/src/ui/store/models/wallet.ts
@@ -148,12 +148,13 @@ export const wallet = createModel<RootModel>()({
         const accountsData: any = await this.loadAccounts();
         if (accountsData && accountsData.length !== 0) {
           const preservedAccountLockArgs = await DB.getItem(STORAGE_KEYS.CURRENT_ACCOUNT_POINTER);
-  
+
           if (preservedAccountLockArgs) {
-            await quantum.setAccountPointer(preservedAccountLockArgs);
+            const accountData = accountsData.find((a: any) => a.spxLockArgs === preservedAccountLockArgs);
+            await quantum.setAccountPointer(preservedAccountLockArgs, accountData?.scheme);
           } else {
             await DB.setItem(STORAGE_KEYS.CURRENT_ACCOUNT_POINTER, accountsData[0].spxLockArgs);
-            await quantum.setAccountPointer(accountsData[0].spxLockArgs);
+            await quantum.setAccountPointer(accountsData[0].spxLockArgs, accountsData[0].scheme);
           }
           this.setActive(true);
         } else {
@@ -175,10 +176,15 @@ export const wallet = createModel<RootModel>()({
           (account) => account.spxLockArgs === accountPointer
         );
         if (!accountData) return;
-        const currentBalance = await quantum.getBalance();
-        const lockInDAO = await quantum.getNervosDaoBalance();
+        const scheme = accountData.scheme ?? "sphincs+";
+        const currentBalance = scheme === "mldsa65"
+          ? await quantum.getMlDsaBalance(accountPointer as Hex)
+          : await quantum.getBalance();
+        const lockInDAO = scheme === "mldsa65"
+          ? BigInt(0)
+          : await quantum.getNervosDaoBalance();
         this.setCurrent({
-          address: quantum.getAddress(accountPointer),
+          address: quantum.getAddress(accountPointer, scheme),
           balance: currentBalance.toString(),
           lockedInDao: lockInDAO.toString(),
           spxLockArgs: accountData.spxLockArgs,

--- a/src/ui/store/models/wallet.ts
+++ b/src/ui/store/models/wallet.ts
@@ -178,12 +178,16 @@ export const wallet = createModel<RootModel>()({
     async createAccount(payload: { password: Uint8Array }, rootState) {
       try {
         await quantum.genAccount(payload.password);
-
-        // Load accounts after creating a new account
         const accountsData: any = await this.loadAccounts();
-
-        // The new account is the last account in the accountsData array
-        // Return it to the caller to explorer the new account
+        return accountsData?.at(-1);
+      } finally {
+        payload.password.fill(0);
+      }
+    },
+    async createMlDsaAccount(payload: { password: Uint8Array }, rootState) {
+      try {
+        await quantum.genMlDsa65Account(payload.password);
+        const accountsData: any = await this.loadAccounts();
         return accountsData?.at(-1);
       } finally {
         payload.password.fill(0);

--- a/src/ui/store/models/wallet.ts
+++ b/src/ui/store/models/wallet.ts
@@ -189,6 +189,7 @@ export const wallet = createModel<RootModel>()({
           lockedInDao: lockInDAO.toString(),
           spxLockArgs: accountData.spxLockArgs,
           name: accountData.name,
+          scheme,
         });
       } catch (error) {
         throw error;
@@ -236,18 +237,16 @@ export const wallet = createModel<RootModel>()({
         clonedPassword.fill(0);
       }
     },
-    async getAccountBalance({ spxLockArgs }) {
+    async getAccountBalance({ spxLockArgs, scheme }, rootState) {
       if (!quantum) return null;
       try {
-        const balance = await quantum.getBalance(spxLockArgs);
-        // this.setAccountBalance({
-        //   spxLockArgs,
-        //   balance: balance.toString(),
-        // });
+        const resolvedScheme = scheme ?? rootState.wallet.current.scheme ?? "sphincs+";
+        const balance = resolvedScheme === "mldsa65"
+          ? await quantum.getMlDsaBalance(spxLockArgs)
+          : await quantum.getBalance(spxLockArgs);
         return balance.toString();
       } catch (error) {
         return "0";
-        // throw error;
       }
     },
     async switchAccount({ spxLockArgs, scheme }, rootState) {

--- a/src/ui/store/models/wallet.ts
+++ b/src/ui/store/models/wallet.ts
@@ -316,6 +316,52 @@ export const wallet = createModel<RootModel>()({
         throw error;
       }
     },
+    async importWalletMlDsa({ srp, password }) {
+      let clonedPassword: Uint8Array = new Uint8Array(password.length);
+      let inloopClonePassword: Uint8Array = new Uint8Array(password.length);
+
+      try {
+        clonedPassword = password.slice();
+        await quantum.importSeedPhrase(srp, password);
+
+        let consecutiveEmpty = 0;
+        let accountIndex = 0;
+        let lastAccountWithBalance = -1;
+        const batchSize = FIND_ACCOUNT_THRESHOLD;
+
+        while (consecutiveEmpty < batchSize) {
+          inloopClonePassword = clonedPassword.slice();
+          const accounts = await quantum.genMlDsa65AccountInBatch(
+            inloopClonePassword,
+            accountIndex,
+            batchSize
+          );
+
+          for (let i = 0; i < accounts.length; i++) {
+            const lockArgs = accounts[i];
+            const balance = await quantum.getMlDsaBalance(lockArgs as Hex);
+
+            if (balance > BigInt(0)) {
+              lastAccountWithBalance = accountIndex + i;
+              consecutiveEmpty = 0;
+            } else {
+              consecutiveEmpty++;
+              if (consecutiveEmpty >= batchSize) break;
+            }
+          }
+          accountIndex += batchSize;
+        }
+
+        const accountsToRecover = lastAccountWithBalance >= 0 ? lastAccountWithBalance + 1 : 1;
+        await quantum.recoverMlDsaAccounts(clonedPassword, accountsToRecover);
+        this.setActive(true);
+      } finally {
+        srp.fill(0);
+        password.fill(0);
+        clonedPassword.fill(0);
+        inloopClonePassword.fill(0);
+      }
+    },
     async importWallet({ srp, password }) {
       // each function call to key-vault clears the password bytes buffer,
       // so clone password for the sequential calls

--- a/src/ui/store/models/wallet.ts
+++ b/src/ui/store/models/wallet.ts
@@ -9,6 +9,7 @@ interface IAccount {
   name: string;
   address: string | null;
   spxLockArgs: string;
+  scheme?: "sphincs+" | "mldsa65";
   balance?: string;
   lockedInDao?: string;
 }
@@ -234,9 +235,9 @@ export const wallet = createModel<RootModel>()({
         // throw error;
       }
     },
-    async switchAccount({ spxLockArgs }, rootState) {
+    async switchAccount({ spxLockArgs, scheme }, rootState) {
       try {
-        await quantum.setAccountPointer(spxLockArgs);
+        await quantum.setAccountPointer(spxLockArgs, scheme);
         this.loadCurrentAccount({});
         await DB.setItem(STORAGE_KEYS.CURRENT_ACCOUNT_POINTER, spxLockArgs);
       } catch (error) {

--- a/src/ui/utils/constants.ts
+++ b/src/ui/utils/constants.ts
@@ -6,6 +6,8 @@ export const ROUTES = {
   COMING_SOON: "/coming-soon",
   CREATE_WALLET: "/create-wallet",
   IMPORT_WALLET: "/import-wallet",
+  CREATE_WALLET_MLDSA: "/create-wallet-mldsa",
+  IMPORT_WALLET_MLDSA: "/import-wallet-mldsa",
   SEND: "/send",
   RECEIVE: "/receive",
   NERVOS_DAO: {

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,6 @@
 {
+    "buildCommand": "npm run build:web",
+    "outputDirectory": "dist",
     "headers": [
         {
             "source": "/(.*)",


### PR DESCRIPTION
## Summary

Adds ML-DSA-65 (FIPS 204) as a second post-quantum signature scheme alongside SPHINCS+, fully integrated end-to-end and verified on testnet.

- **No breaking changes** — all existing SPHINCS+ accounts unchanged
- **Same master seed** — ML-DSA-65 derives via distinct HKDF path, no new backup needed
- **Tested on testnet** — 10,000 CKB received and balance confirmed in UI

## Key fixes discovered during testing

- `setSellectiveSyncFilterInternal` and `setSellectiveSyncFilter` both used `getLockScript()` (SPHINCS+ lock) for every account — ML-DSA accounts were registering the wrong lock script with the light client, so balances never appeared. Both now accept a `scheme` parameter.
- `setAccountPointer` called without scheme in `init()` — caused "Invalid SPHINCS+ account pointer" error when loading an ML-DSA wallet after creation/import.
- `loadCurrentAccount` used `getBalance()`/`getAddress()` without scheme — wrong lock script queried for ML-DSA accounts.
- SPHINCS+ variant picker for ML-DSA wallets removed — ML-DSA key derivation is scheme-independent; internal default (`Sha2128S`) used silently.

## Changes

### Core (`src/core/quantum_purse.ts`)
- `genMlDsa65Account` — new ML-DSA-65 account, registers with light client using MLDSA_LOCK
- `genMlDsa65AccountInBatch` — batch derivation for import discovery
- `recoverMlDsaAccounts` — derives and persists accounts, registers with light client using MLDSA_LOCK
- `getMlDsaBalance` — balance lookup via light client using MLDSA_LOCK
- `setSellectiveSyncFilterInternal` / `setSellectiveSyncFilter` — added `scheme` param, use correct lock per scheme

### Store (`src/ui/store/models/wallet.ts`)
- `init()` — passes scheme to `setAccountPointer` from accounts data
- `loadCurrentAccount()` — scheme-aware balance and address lookup
- `importWalletMlDsa` — full discovery loop using ML-DSA batch generation + balance check
- `createWalletMlDsa`, `createMlDsaAccount`, `loadAccounts`, `switchAccount` — full ML-DSA support

### UI
- Flat `<Select>` with OptGroups — ML-DSA-65 at top, all 12 SPHINCS+ variants below
- CreateWallet / ImportWallet — scheme selector only; no redundant SPHINCS+ variant picker for ML-DSA
- Accounts page — segmented control to switch between scheme types for account creation

### CCC Adapter (`src/core/ccc-adapter/qp_signer.ts`)
- `setAccountPointer` — validates against correct DB store per scheme, sets `sigScheme`
- `activeLock` getter — switches between MLDSA_LOCK and spxLock
- `signOnlyTransaction` — routes ML-DSA and SPHINCS+ signing correctly

## Depends On

[`QuantumPurse/key-vault-wasm#11`](https://github.com/QuantumPurse/key-vault-wasm/pull/11) — adds ML-DSA-65 WASM, DB schema v2, `gen_new_ml_dsa_account`, `try_gen_ml_dsa_account_batch`, `recover_ml_dsa_accounts`

## Test Plan

- [x] ML-DSA-65 wallet creation completes without error
- [x] ML-DSA-65 address displayed correctly (72-byte lock args, longer bech32)
- [x] Faucet funds received and balance shows in UI (10,000 CKB confirmed)
- [x] ML-DSA-65 wallet import via seed phrase
- [x] SPHINCS+ wallet creation unchanged
- [ ] ML-DSA-65 signing produces valid witness — send tx to verify
- [ ] Existing SPHINCS+ accounts survive schema v1 → v2 migration